### PR TITLE
Add database init script and decouple default admin creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-<p>npm i</p> 
-<p>npm i sqlite</p> 
-<p>npm start</p> 
+<p>npm i</p>
+<p>npm i sqlite</p>
+<p>npm run db:init</p>
+<p>npm start</p>
 
-<p>default admin is admin / admin</p> 
+<p>default admin is admin / admin (created during <code>npm run db:init</code>)</p>

--- a/db.js
+++ b/db.js
@@ -3,6 +3,9 @@ import { open } from 'sqlite';
 
 let db;
 export async function initDb(){
+  if(db){
+    return db;
+  }
   db = await open({ filename: './data.sqlite', driver: sqlite3.Database });
   await db.exec(`
   PRAGMA foreign_keys=ON;
@@ -47,17 +50,21 @@ export async function initDb(){
     UNIQUE(page_id, ip)
   );
   `);
-  // default admin
+  return db;
+}
+
+export async function get(sql, params=[]){ return db.get(sql, params); }
+export async function all(sql, params=[]){ return db.all(sql, params); }
+export async function run(sql, params=[]){ return db.run(sql, params); }
+
+export async function ensureDefaultAdmin(){
+  await initDb();
   const admin = await db.get('SELECT 1 FROM users WHERE username=?', ['admin']);
   if(!admin){
     await db.run('INSERT INTO users(username,password,is_admin) VALUES(?,?,1)', ['admin','admin']);
     console.log('Default admin created: admin / admin');
   }
 }
-
-export async function get(sql, params=[]){ return db.get(sql, params); }
-export async function all(sql, params=[]){ return db.all(sql, params); }
-export async function run(sql, params=[]){ return db.run(sql, params); }
 
 export function randSlugId(base){
   const id = Math.random().toString(36).slice(2,8);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "dev": "node --watch app.js"
+    "dev": "node --watch app.js",
+    "db:init": "node scripts/db-init.js"
   },
   "dependencies": {
     "ejs": "^3.1.9",

--- a/scripts/db-init.js
+++ b/scripts/db-init.js
@@ -1,0 +1,6 @@
+import { initDb, ensureDefaultAdmin } from '../db.js';
+
+await initDb();
+await ensureDefaultAdmin();
+
+console.log('Database initialized.');


### PR DESCRIPTION
## Summary
- avoid recreating the default admin account during normal app startup
- add a reusable database initialization script that seeds the default admin on demand
- document the new setup flow including the explicit database initialization step

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68d78f3856d08321b2f3bed5b22fb722