### PR TITLE
feat: manage uploaded images in admin panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+public/uploads/*
+!public/uploads/.gitkeep

--- a/db.js
+++ b/db.js
@@ -49,6 +49,14 @@ export async function initDb(){
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(page_id, ip)
   );
+  CREATE TABLE IF NOT EXISTS uploads(
+    id TEXT PRIMARY KEY,
+    original_name TEXT NOT NULL,
+    display_name TEXT,
+    extension TEXT NOT NULL,
+    size INTEGER,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
   `);
   return db;
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "express": "^4.19.2",
     "express-ejs-layouts": "^2.5.1",
     "express-session": "^1.17.3",
+    "multer": "^1.4.5-lts.1",
     "method-override": "^3.0.0",
     "morgan": "^1.10.0",
     "node-fetch": "^3.3.2",

--- a/utils/uploads.js
+++ b/utils/uploads.js
@@ -1,0 +1,141 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { all, get, run } from '../db.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const uploadDir = path.join(__dirname, '..', 'public', 'uploads');
+
+export async function ensureUploadDir() {
+  await fs.mkdir(uploadDir, { recursive: true });
+}
+
+export function buildFilename(id, extension) {
+  return `${id}${extension}`;
+}
+
+export async function recordUpload({ id, originalName, displayName, extension, size }) {
+  await ensureUploadDir();
+  await run(
+    `INSERT INTO uploads(id, original_name, display_name, extension, size)
+     VALUES(?,?,?,?,?)
+     ON CONFLICT(id) DO UPDATE SET
+       original_name=excluded.original_name,
+       display_name=excluded.display_name,
+       extension=excluded.extension,
+       size=excluded.size`,
+    [id, originalName, displayName, extension, size]
+  );
+}
+
+export async function listUploads() {
+  await ensureUploadDir();
+  const entries = [];
+  const seen = new Set();
+  const rows = await all(
+    'SELECT id, original_name, display_name, extension, size, created_at FROM uploads ORDER BY created_at DESC'
+  );
+
+  for (const row of rows) {
+    const extension = row.extension || '';
+    const filename = buildFilename(row.id, extension);
+    if (!filename || filename.startsWith('.')) {
+      continue;
+    }
+    const filePath = path.join(uploadDir, filename);
+    try {
+      const stat = await fs.stat(filePath);
+      const createdAtIso = row.created_at
+        ? new Date(row.created_at).toISOString()
+        : new Date(stat.mtimeMs).toISOString();
+      entries.push({
+        id: row.id,
+        filename,
+        url: '/public/uploads/' + filename,
+        originalName: row.original_name || filename,
+        displayName: row.display_name || '',
+        extension,
+        size: stat.size,
+        createdAt: createdAtIso,
+        mtime: stat.mtimeMs
+      });
+      seen.add(filename);
+      if (!row.size || row.size !== stat.size) {
+        await run('UPDATE uploads SET size=? WHERE id=?', [stat.size, row.id]);
+      }
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        await run('DELETE FROM uploads WHERE id=?', [row.id]);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  const files = await fs.readdir(uploadDir);
+  for (const name of files) {
+    if (name.startsWith('.')) continue;
+    if (seen.has(name)) continue;
+    const filePath = path.join(uploadDir, name);
+    const stat = await fs.stat(filePath);
+    const ext = path.extname(name).toLowerCase();
+    const id = path.basename(name, ext);
+    await run(
+      'INSERT OR IGNORE INTO uploads(id, original_name, display_name, extension, size) VALUES(?,?,?,?,?)',
+      [id, name, null, ext, stat.size]
+    );
+    entries.push({
+      id,
+      filename: name,
+      url: '/public/uploads/' + name,
+      originalName: name,
+      displayName: '',
+      extension: ext,
+      size: stat.size,
+      createdAt: new Date(stat.mtimeMs).toISOString(),
+      mtime: stat.mtimeMs
+    });
+    seen.add(name);
+  }
+
+  entries.sort((a, b) => (b.mtime ?? 0) - (a.mtime ?? 0));
+  return entries;
+}
+
+export async function removeUpload(id) {
+  await ensureUploadDir();
+  const row = await get('SELECT extension FROM uploads WHERE id=?', [id]);
+  let filename = null;
+  if (row && row.extension) {
+    filename = buildFilename(id, row.extension);
+  }
+
+  if (!filename) {
+    const files = await fs.readdir(uploadDir);
+    filename = files.find((name) => !name.startsWith('.') && name.startsWith(id));
+  }
+
+  if (filename) {
+    const filePath = path.join(uploadDir, filename);
+    try {
+      await fs.unlink(filePath);
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        throw err;
+      }
+    }
+  }
+
+  await run('DELETE FROM uploads WHERE id=?', [id]);
+}
+
+export async function updateUploadName(id, displayName) {
+  const row = await get('SELECT 1 FROM uploads WHERE id=?', [id]);
+  if (!row) {
+    return false;
+  }
+  await run('UPDATE uploads SET display_name=? WHERE id=?', [displayName, id]);
+  return true;
+}

--- a/views/admin/uploads.ejs
+++ b/views/admin/uploads.ejs
@@ -1,0 +1,52 @@
+<% title='Images'; %>
+<h1>Gestion des images</h1>
+<div class="card" style="margin-bottom:16px">
+  <p>Chaque image reçoit un identifiant unique (UUID). Vous pouvez supprimer les fichiers inutiles ou définir un nom personnalisé sans changer cet identifiant. Laissez le champ vide pour effacer un nom personnalisé.</p>
+</div>
+
+<% if (uploads.length) { %>
+  <div class="table-wrap">
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th>Aperçu</th>
+          <th>Détails</th>
+          <th>Nom personnalisé</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% uploads.forEach(upload => { %>
+          <% const displayName = upload.displayName || ''; %>
+          <% const createdAt = upload.createdAt ? new Date(upload.createdAt).toLocaleString('fr-FR') : '—'; %>
+          <% const sizeLabel = upload.size ? Math.max(1, Math.round(upload.size / 1024)) + ' Ko' : '—'; %>
+          <tr>
+            <td>
+              <img src="<%= upload.url %>" alt="" style="max-width:140px; max-height:90px; object-fit:contain; border-radius:8px" />
+            </td>
+            <td style="line-height:1.4">
+              <div><strong>UUID :</strong> <code><%= upload.id %></code></div>
+              <div><strong>Nom original :</strong> <%= upload.originalName %></div>
+              <div><strong>Nom affiché :</strong> <%= displayName || '—' %></div>
+              <div><strong>Taille :</strong> <%= sizeLabel %></div>
+              <div><strong>Ajouté :</strong> <%= createdAt %></div>
+            </td>
+            <td>
+              <form method="post" action="/admin/uploads/<%= upload.id %>/name" style="display:flex; flex-direction:column; gap:8px; min-width:220px">
+                <input type="text" name="displayName" value="<%= displayName %>" maxlength="120" placeholder="Nom personnalisé" />
+                <button class="btn" type="submit">Enregistrer</button>
+              </form>
+            </td>
+            <td>
+              <form method="post" action="/admin/uploads/<%= upload.id %>/delete" onsubmit="return confirm('Supprimer cette image ?')">
+                <button class="btn unlike" type="submit">Supprimer</button>
+              </form>
+            </td>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
+  </div>
+<% } else { %>
+  <p class="card" style="color:var(--muted)">Aucune image disponible pour le moment.</p>
+<% } %>

--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -11,3 +11,223 @@
     <button class="btn success">Enregistrer</button>
   </div>
 </form>
+
+<% const uploadList = uploads || []; %>
+<div class="card" style="margin-top:16px">
+  <h2>Images</h2>
+  <p style="margin-top:8px">Envoyez une image puis insérez-la dans votre article avec le code <code>&lt;img src="…" alt="" /&gt;</code>.</p>
+  <form id="uploadForm" action="/admin/uploads" method="post" enctype="multipart/form-data" style="margin-top:12px">
+    <input type="file" name="image" id="imageInput" accept="image/*" required />
+    <input type="text" name="displayName" id="displayNameInput" placeholder="Nom personnalisé (optionnel)" style="margin-top:8px" maxlength="120" />
+    <button class="btn" type="submit">Uploader</button>
+  </form>
+  <div id="uploadMessage" style="margin-top:12px"></div>
+
+  <h3 style="margin-top:16px">Images déjà envoyées</h3>
+  <div id="uploadsList" class="uploads-grid" style="display:grid; gap:12px; grid-template-columns:repeat(auto-fill,minmax(220px,1fr)); margin-top:12px">
+    <% uploadList.forEach(file => { %>
+      <% const displayName = file.displayName || ''; %>
+      <% const originalName = file.originalName || file.name; %>
+      <% const uuid = file.id || (file.name ? file.name.split('.')[0] : file.name); %>
+      <div class="upload-item card" data-url="<%= file.url %>" data-alt="<%= displayName %>" style="padding:12px; display:flex; flex-direction:column; gap:8px">
+        <div style="text-align:center">
+          <img src="<%= file.url %>" alt="" style="max-width:100%; max-height:120px; object-fit:contain" />
+        </div>
+        <div style="font-size:0.9em; line-height:1.4">
+          <div><strong>UUID :</strong> <code><%= uuid %></code></div>
+          <div><strong>Nom affiché :</strong> <span class="upload-display" style="color:<%= displayName ? 'inherit' : 'var(--muted)' %>"><%= displayName || '—' %></span></div>
+          <div><strong>Nom original :</strong> <span><%= originalName %></span></div>
+        </div>
+        <code class="upload-snippet"></code>
+        <button class="btn copy-upload" type="button">Copier le code</button>
+      </div>
+    <% }) %>
+  </div>
+  <% if (!uploadList.length) { %>
+    <p id="uploadsEmptyMessage" style="margin-top:12px; color:var(--muted)">Aucune image envoyée pour le moment.</p>
+  <% } %>
+</div>
+
+<script>
+  const uploadForm = document.getElementById('uploadForm');
+  const imageInput = document.getElementById('imageInput');
+  const displayNameInput = document.getElementById('displayNameInput');
+  const uploadMessage = document.getElementById('uploadMessage');
+  const uploadsList = document.getElementById('uploadsList');
+
+  function setMessage(content, type = 'info') {
+    uploadMessage.textContent = '';
+    if (!content) return;
+    const box = document.createElement('div');
+    box.textContent = content;
+    box.style.marginTop = '8px';
+    box.style.padding = '8px 12px';
+    box.style.borderRadius = '6px';
+    if (type === 'error') {
+      box.style.backgroundColor = '#ffe5e5';
+      box.style.color = '#a60000';
+    } else {
+      box.style.backgroundColor = '#e5f6ff';
+      box.style.color = '#005a8c';
+    }
+    uploadMessage.appendChild(box);
+  }
+
+  function buildSnippet(url, alt) {
+    const img = document.createElement('img');
+    img.src = url;
+    if (alt) {
+      img.alt = alt;
+    }
+    return img.outerHTML;
+  }
+
+  function enhanceUploadItem(item) {
+    if (!item) return;
+    const url = item.dataset.url;
+    const alt = item.dataset.alt || '';
+    const snippet = buildSnippet(url, alt);
+    const code = item.querySelector('.upload-snippet');
+    if (code) {
+      code.textContent = snippet;
+    }
+    const button = item.querySelector('.copy-upload');
+    if (button) {
+      button.dataset.snippet = snippet;
+    }
+  }
+
+  function createUploadItem(data) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'upload-item card';
+    wrapper.style.padding = '12px';
+    wrapper.style.display = 'flex';
+    wrapper.style.flexDirection = 'column';
+    wrapper.style.gap = '8px';
+    wrapper.dataset.url = data.url;
+    wrapper.dataset.alt = data.displayName || '';
+
+    const preview = document.createElement('div');
+    preview.style.textAlign = 'center';
+    const img = document.createElement('img');
+    img.src = data.url;
+    img.alt = data.displayName || data.originalName || '';
+    img.style.maxWidth = '100%';
+    img.style.maxHeight = '120px';
+    img.style.objectFit = 'contain';
+    preview.appendChild(img);
+    wrapper.appendChild(preview);
+
+    const info = document.createElement('div');
+    info.style.fontSize = '0.9em';
+    info.style.lineHeight = '1.4';
+
+    const uuidLine = document.createElement('div');
+    const uuidLabel = document.createElement('strong');
+    uuidLabel.textContent = 'UUID : ';
+    uuidLine.appendChild(uuidLabel);
+    const uuidCode = document.createElement('code');
+    uuidCode.textContent = data.id;
+    uuidLine.appendChild(uuidCode);
+    info.appendChild(uuidLine);
+
+    const displayLine = document.createElement('div');
+    const displayLabel = document.createElement('strong');
+    displayLabel.textContent = 'Nom affiché : ';
+    displayLine.appendChild(displayLabel);
+    const displaySpan = document.createElement('span');
+    if (data.displayName) {
+      displaySpan.textContent = data.displayName;
+    } else {
+      displaySpan.textContent = '—';
+      displaySpan.style.color = 'var(--muted)';
+    }
+    displayLine.appendChild(displaySpan);
+    info.appendChild(displayLine);
+
+    const originalLine = document.createElement('div');
+    const originalLabel = document.createElement('strong');
+    originalLabel.textContent = 'Nom original : ';
+    originalLine.appendChild(originalLabel);
+    const originalSpan = document.createElement('span');
+    originalSpan.textContent = data.originalName || data.name || '';
+    originalLine.appendChild(originalSpan);
+    info.appendChild(originalLine);
+
+    wrapper.appendChild(info);
+
+    const code = document.createElement('code');
+    code.className = 'upload-snippet';
+    wrapper.appendChild(code);
+
+    const button = document.createElement('button');
+    button.className = 'btn copy-upload';
+    button.type = 'button';
+    button.textContent = 'Copier le code';
+    wrapper.appendChild(button);
+
+    return wrapper;
+  }
+
+  if (uploadsList) {
+    uploadsList.querySelectorAll('.upload-item').forEach(enhanceUploadItem);
+  }
+
+  if (uploadForm) {
+    uploadForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!imageInput.files.length) {
+        setMessage('Choisissez un fichier avant d\'uploader.', 'error');
+        return;
+      }
+      const button = uploadForm.querySelector('button[type="submit"]');
+      button.disabled = true;
+      setMessage('Upload en cours…');
+      const formData = new FormData(uploadForm);
+      if (displayNameInput && displayNameInput.value) {
+        formData.set('displayName', displayNameInput.value.trim());
+      }
+      try {
+        const res = await fetch(uploadForm.action, { method: 'POST', body: formData });
+        const data = await res.json();
+        if (data.ok && data.url) {
+          const snippet = buildSnippet(data.url, data.displayName || '');
+          setMessage(`Image envoyée ! Code à insérer : ${snippet}`);
+          if (uploadsList) {
+            const wrapper = createUploadItem({
+              url: data.url,
+              id: data.id,
+              displayName: data.displayName || '',
+              originalName: data.originalName || ''
+            });
+            const emptyMessage = document.getElementById('uploadsEmptyMessage');
+            if (emptyMessage) {
+              emptyMessage.remove();
+            }
+            uploadsList.prepend(wrapper);
+            enhanceUploadItem(wrapper);
+          }
+        } else {
+          throw new Error(data.message || 'Erreur inconnue');
+        }
+      } catch (err) {
+        setMessage(err.message || 'Erreur lors de l\'upload.', 'error');
+      } finally {
+        button.disabled = false;
+        uploadForm.reset();
+      }
+    });
+  }
+
+  document.addEventListener('click', (event) => {
+    const button = event.target.closest('.copy-upload');
+    if (!button) return;
+    const snippet = button.dataset.snippet;
+    navigator.clipboard.writeText(snippet).then(() => {
+      button.textContent = 'Copié !';
+      setTimeout(() => {
+        button.textContent = 'Copier le code';
+      }, 1500);
+    });
+  });
+</script>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -37,6 +37,7 @@
         <a href="/new">➕ Nouvelle page</a>
         <a href="/admin/users">👤 Utilisateurs</a>
         <a href="/admin/likes">❤️ Likes</a>
+        <a href="/admin/uploads">🖼️ Images</a>
         <a href="/admin/settings">⚙️ Paramètres</a>
       <% } %>
     </nav>


### PR DESCRIPTION
## Summary
- persist upload metadata so images use UUID-based filenames while tracking original and custom names
- add an admin images tab to rename or delete uploads and keep hidden files like .gitkeep out of listings
- update the editor upload widget to accept optional display names and surface the new snippets immediately

## Testing
- node --check routes/admin.js
- node --check routes/pages.js
- node --check utils/uploads.js

------
https://chatgpt.com/codex/tasks/task_e_68d7925b2884832192da7c88bff664ab