### PR TITLE
Refine article image sizing

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -148,7 +148,14 @@ form .actions{ margin-top:14px; gap:12px }
 .prose p{ margin:.7em 0 }
 .prose ul,.prose ol{ padding-left:1.2em; margin:.7em 0 }
 .prose blockquote{ margin:.8em 0; padding:.6em 1em; border-left:3px solid var(--border); background:#111726; border-radius:8px }
-.prose img{ max-width:100%; height:auto; border-radius:8px }
+.prose img{
+  display:block;
+  margin:16px auto;
+  max-width:min(100%, 640px);
+  width:auto;
+  height:auto;
+  border-radius:8px;
+}
 .prose code{ background:#0c0f18; border:1px solid #242a3a; padding:.1rem .35rem; border-radius:6px }
 .prose pre{ margin:.8em 0 }
 


### PR DESCRIPTION
## Summary
- remove the forced 16:9 aspect ratio from article images so they retain their original proportions
- cap article image width at 640px so visuals remain smaller while still centered in the content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a65555708321a13f8b312134f07e