### PR TITLE
Remove image management note from edit page

### DIFF
--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -12,7 +12,3 @@
   </div>
 </form>
 
-<div class="card" style="margin-top:16px">
-  <h2>Images</h2>
-  <p style="margin-top:8px">Gérez vos fichiers et récupérez le code d'intégration depuis l'onglet <strong>Admin &gt; Images</strong>.</p>
-</div>


### PR DESCRIPTION
## Summary
- remove the informational card about image management from the edit page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7a9c802cc8321a01e39f10278a743