### PR TITLE
Add revision history support for wiki pages

### DIFF
--- a/db.js
+++ b/db.js
@@ -34,6 +34,15 @@ export async function initDb() {
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME
   );
+  CREATE TABLE IF NOT EXISTS page_revisions(
+    page_id INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    revision INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    author_id INTEGER REFERENCES users(id),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(page_id, revision)
+  );
   CREATE TABLE IF NOT EXISTS page_views(
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     page_id INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,

--- a/views/history.ejs
+++ b/views/history.ejs
@@ -1,0 +1,38 @@
+<% title = `Historique · ${page.title}`; %>
+<div class="card">
+  <h1>Historique de « <%= page.title %> »</h1>
+  <p>Slug : <code><%= page.slug_id %></code></p>
+</div>
+
+<div class="card">
+  <% if (!revisions.length) { %>
+    <p>Aucune révision enregistrée pour cette page.</p>
+  <% } else { %>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Titre</th>
+          <th>Auteur</th>
+          <th>Créée le</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% revisions.forEach((rev) => { %>
+          <tr>
+            <td><%= rev.revision %></td>
+            <td><%= rev.title %></td>
+            <td><%= rev.author || 'Inconnu' %></td>
+            <td><%= rev.created_at %></td>
+            <td><a class="btn" href="/wiki/<%= page.slug_id %>/revisions/<%= rev.revision %>">Consulter</a></td>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
+  <% } %>
+</div>
+
+<div class="card">
+  <a class="btn" href="/wiki/<%= page.slug_id %>">← Retour à la page</a>
+</div>

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -20,6 +20,7 @@
     <button class="btn copy" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= page.slug_id %>')">Copier le lien</button>
     <% if (user && user.is_admin) { %>
       <a class="btn" href="/edit/<%= page.slug_id %>">Éditer</a>
+      <a class="btn" href="/wiki/<%= page.slug_id %>/history">Historique</a>
       <form action="/delete/<%= page.slug_id %>" method="post" onsubmit="return confirm('Supprimer ?')">
         <input type="hidden" name="_method" value="DELETE" />
         <button class="btn">Supprimer</button>

--- a/views/revision.ejs
+++ b/views/revision.ejs
@@ -1,0 +1,16 @@
+<% title = `Révision ${revision.revision} · ${page.title}`; %>
+<div class="card">
+  <h1>Révision #<%= revision.revision %> de « <%= page.title %> »</h1>
+  <p><strong>Titre enregistré :</strong> <%= revision.title %></p>
+  <p><strong>Auteur :</strong> <%= revision.author || 'Inconnu' %></p>
+  <p><strong>Horodatage :</strong> <%= revision.created_at %></p>
+</div>
+
+<div class="card prose">
+  <div><%- html %></div>
+</div>
+
+<div class="card">
+  <a class="btn" href="/wiki/<%= page.slug_id %>/history">← Retour à l'historique</a>
+  <a class="btn" href="/wiki/<%= page.slug_id %>">Voir la page actuelle</a>
+</div>


### PR DESCRIPTION
## Summary
- add a `page_revisions` table to store snapshots of pages
- record revisions during page creation and edits and expose history routes
- introduce history and revision views plus an admin link from the page view

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68d7de88fd8883218c1134734dac7ced