### PR TITLE
Add moderated comments feature

### DIFF
--- a/db.js
+++ b/db.js
@@ -73,6 +73,17 @@ export async function initDb() {
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(page_id, ip)
   );
+  CREATE TABLE IF NOT EXISTS comments(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    author TEXT,
+    body TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    status TEXT NOT NULL DEFAULT 'pending'
+      CHECK(status IN ('pending','approved','rejected'))
+  );
+  CREATE INDEX IF NOT EXISTS idx_comments_page_status
+    ON comments(page_id, status);
   CREATE TABLE IF NOT EXISTS uploads(
     id TEXT PRIMARY KEY,
     original_name TEXT NOT NULL,

--- a/public/style.css
+++ b/public/style.css
@@ -414,6 +414,134 @@ form .actions {
   border-bottom: none;
 }
 
+/* === COMMENTAIRES === */
+.notice {
+  padding: 12px 16px;
+  border-radius: 10px;
+  margin-bottom: 18px;
+  border: 1px solid var(--border);
+  background: rgba(88, 101, 242, 0.1);
+}
+.notice.success {
+  border-color: rgba(87, 242, 135, 0.5);
+  background: rgba(87, 242, 135, 0.12);
+  color: #bbf7d0;
+}
+.notice.error {
+  border-color: rgba(237, 66, 69, 0.5);
+  background: rgba(237, 66, 69, 0.14);
+  color: #fecaca;
+}
+
+.comments .comment-list,
+.admin-comment-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.comments .comment {
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 14px;
+  background: rgba(17, 23, 38, 0.6);
+}
+
+.comment-meta {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+
+.comment-body {
+  white-space: pre-wrap;
+  line-height: 1.7;
+}
+
+.comment-empty {
+  color: var(--muted);
+}
+
+.comment-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.comment-form .field {
+  display: flex;
+  flex-direction: column;
+}
+
+.comment-form textarea {
+  min-height: 140px;
+}
+
+.comment-form .honeypot {
+  position: absolute;
+  left: -10000px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.admin-comment-list li {
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 16px;
+  background: rgba(17, 23, 38, 0.5);
+}
+
+.admin-comment-list header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+  color: var(--muted);
+}
+
+.admin-comment-list .actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.admin-comment-list p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.admin-comment-list.compact li {
+  padding: 14px;
+}
+
+.admin-comment-list .status {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.admin-comment-list .status.approved {
+  border-color: rgba(87, 242, 135, 0.5);
+  color: #bef7cc;
+}
+
+.admin-comment-list .status.rejected {
+  border-color: rgba(237, 66, 69, 0.5);
+  color: #fecaca;
+}
+
 img,
 video,
 iframe {

--- a/views/admin/comments.ejs
+++ b/views/admin/comments.ejs
@@ -1,0 +1,63 @@
+<h1>Modération des commentaires</h1>
+
+<% if (notice) { %>
+  <div class="card" style="padding:16px; margin-bottom:20px; border:1px solid <%= notice.type === 'error' ? '#f87171' : '#4ade80' %>; background:<%= notice.type === 'error' ? 'rgba(248,113,113,0.15)' : 'rgba(74,222,128,0.12)' %>; border-radius:12px;">
+    <strong><%= notice.message %></strong>
+  </div>
+<% } %>
+
+<section class="card" style="margin-bottom:24px;">
+  <h2 style="margin-top:0;">En attente de validation (<%= pending.length %>)</h2>
+  <% if (!pending.length) { %>
+    <p>Aucun commentaire en attente.</p>
+  <% } else { %>
+    <ul class="admin-comment-list">
+      <% pending.forEach(c => { %>
+        <li>
+          <header>
+            <div>
+              <strong><%= c.author || 'Anonyme' %></strong>
+              <span>· <%= new Date(c.created_at).toLocaleString('fr-FR') %></span>
+            </div>
+            <a class="tag" href="/wiki/<%= c.page_slug %>" target="_blank" rel="noopener">Voir la page</a>
+          </header>
+          <p><%= c.body %></p>
+          <div class="actions">
+            <form method="post" action="/admin/comments/<%= c.id %>/approve">
+              <button class="btn success" type="submit">Approuver</button>
+            </form>
+            <form method="post" action="/admin/comments/<%= c.id %>/reject">
+              <button class="btn" type="submit">Rejeter</button>
+            </form>
+            <form method="post" action="/admin/comments/<%= c.id %>" onsubmit="return confirm('Supprimer ce commentaire ?');">
+              <input type="hidden" name="_method" value="DELETE">
+              <button class="btn unlike" type="submit">Supprimer</button>
+            </form>
+          </div>
+        </li>
+      <% }) %>
+    </ul>
+  <% } %>
+</section>
+
+<section class="card">
+  <h2 style="margin-top:0;">Historique récent</h2>
+  <% if (!recent.length) { %>
+    <p>Aucun commentaire modéré pour le moment.</p>
+  <% } else { %>
+    <ul class="admin-comment-list compact">
+      <% recent.forEach(c => { %>
+        <li>
+          <header>
+            <div>
+              <strong><%= c.author || 'Anonyme' %></strong>
+              <span>· <%= new Date(c.created_at).toLocaleString('fr-FR') %> · <span class="status <%= c.status %>"><%= c.status %></span></span>
+            </div>
+            <a class="tag" href="/wiki/<%= c.page_slug %>" target="_blank" rel="noopener">Voir la page</a>
+          </header>
+          <p><%= c.body %></p>
+        </li>
+      <% }) %>
+    </ul>
+  <% } %>
+</section>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -38,6 +38,7 @@
         <a href="/admin/pages">📄 Articles</a>
         <a href="/admin/stats">📈 Statistiques</a>
         <a href="/admin/users">👤 Utilisateurs</a>
+        <a href="/admin/comments">💬 Commentaires</a>
         <a href="/admin/likes">❤️ Likes</a>
         <a href="/admin/uploads">🖼️ Images</a>
         <a href="/admin/settings">⚙️ Paramètres</a>

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -43,3 +43,57 @@
     </div>
   </div>
 <% } %>
+
+<% const commentValues = (commentFeedback && commentFeedback.values) || {}; %>
+<section class="card comments" id="comments">
+  <h2 style="margin-top:0">Commentaires</h2>
+  <% if (commentFeedback && commentFeedback.success) { %>
+    <div class="notice success">Merci ! Votre commentaire a été enregistré et sera publié après validation.</div>
+  <% } %>
+  <% if (commentFeedback && commentFeedback.errors && commentFeedback.errors.length) { %>
+    <div class="notice error">
+      <p style="margin-top:0;">Impossible d'enregistrer le commentaire :</p>
+      <ul>
+        <% commentFeedback.errors.forEach(err => { %>
+          <li><%= err %></li>
+        <% }) %>
+      </ul>
+    </div>
+  <% } %>
+
+  <% if (comments && comments.length) { %>
+    <ul class="comment-list">
+      <% comments.forEach(c => { %>
+        <li class="comment">
+          <div class="comment-meta">
+            <strong><%= c.author || 'Anonyme' %></strong>
+            <span>· <%= new Date(c.created_at).toLocaleString('fr-FR') %></span>
+          </div>
+          <div class="comment-body"><%= c.body %></div>
+        </li>
+      <% }) %>
+    </ul>
+  <% } else { %>
+    <p class="comment-empty">Aucun commentaire pour le moment.</p>
+  <% } %>
+
+  <form class="comment-form" method="post" action="/wiki/<%= page.slug_id %>/comments">
+    <div class="field">
+      <label for="comment-author">Nom ou pseudo (facultatif)</label>
+      <input id="comment-author" type="text" name="author" maxlength="80" value="<%= commentValues.author || '' %>">
+    </div>
+    <div class="field">
+      <label for="comment-body">Votre message <span style="color:#f87171;">*</span></label>
+      <textarea id="comment-body" name="body" rows="5" maxlength="2000" required><%= commentValues.body || '' %></textarea>
+    </div>
+    <div class="field">
+      <label for="comment-captcha">Question anti-spam : 3 + 4 = ? <span style="color:#f87171;">*</span></label>
+      <input id="comment-captcha" type="text" name="captcha" inputmode="numeric" pattern="[0-9]*" required>
+    </div>
+    <div class="field honeypot">
+      <label for="comment-website">Ne pas remplir</label>
+      <input id="comment-website" type="text" name="website" tabindex="-1" autocomplete="off">
+    </div>
+    <button class="btn" type="submit">Envoyer mon commentaire</button>
+  </form>
+</section>


### PR DESCRIPTION
## Summary
- add a comments table to persist visitor feedback with review status
- allow visitors to submit comments with basic anti-spam checks and render approved messages on pages
- provide an admin moderation screen with actions to approve, reject, or delete comments and add related styling

## Testing
- npm run db:init


------
https://chatgpt.com/codex/tasks/task_e_68d7e2398db08321b1aa74380e4f6c1c