### PR TITLE
Add SQLite FTS search index

### DIFF
--- a/routes/search.js
+++ b/routes/search.js
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { all } from "../db.js";
+import { all, isFtsAvailable } from "../db.js";
 
 const r = Router();
 
@@ -7,32 +7,100 @@ r.get("/search", async (req, res) => {
   const q = (req.query.q || "").trim();
   if (!q) return res.redirect("/");
 
-  // Recherche par titre, contenu ET tags
-  const rows = await all(
-    `
-    SELECT DISTINCT
-      p.title,
-      p.slug_id,
-      substr(p.content, 1, 400) AS excerpt,
-      (
-        SELECT GROUP_CONCAT(t2.name, ',')
-        FROM tags t2
-        JOIN page_tags pt2 ON pt2.tag_id = t2.id
-        WHERE pt2.page_id = p.id
-      ) AS tagsCsv
-    FROM pages p
-    LEFT JOIN page_tags pt ON pt.page_id = p.id
-    LEFT JOIN tags t ON t.id = pt.tag_id
-    WHERE p.title   LIKE '%'||?||'%'
-       OR p.content LIKE '%'||?||'%'
-       OR t.name    LIKE '%'||?||'%'
-    ORDER BY p.updated_at DESC, p.created_at DESC
-    LIMIT 100
-  `,
-    [q, q, q],
-  );
+  const ftsPossible = isFtsAvailable();
+  let mode = "fts";
+  let rows = [];
 
-  res.render("search", { q, rows });
+  const tokens = tokenize(q);
+  if (ftsPossible && tokens.length) {
+    const matchQuery = tokens.map((t) => `${t}*`).join(" AND ");
+    try {
+      const ftsRows = await all(
+        `
+        SELECT
+          p.slug_id,
+          p.title,
+          substr(p.content, 1, 400) AS excerpt,
+          bm25(pages_fts) AS score,
+          snippet(pages_fts, 'content', '<mark>', '</mark>', '…', 20) AS contentSnippet,
+          snippet(pages_fts, 'tags', '<mark>', '</mark>', '…', 10) AS tagsSnippet,
+          (
+            SELECT GROUP_CONCAT(t2.name, ',')
+            FROM tags t2
+            JOIN page_tags pt2 ON pt2.tag_id = t2.id
+            WHERE pt2.page_id = p.id
+          ) AS tagsCsv
+        FROM pages_fts
+        JOIN pages p ON p.id = pages_fts.rowid
+        WHERE pages_fts MATCH ?
+        ORDER BY score ASC, p.updated_at DESC, p.created_at DESC
+        LIMIT 100
+      `,
+        [matchQuery],
+      );
+      rows = ftsRows.map((row) => {
+        const numericScore = Number(row.score);
+        return {
+          ...row,
+          snippet: chooseSnippet(row),
+          score: Number.isFinite(numericScore) ? numericScore : null,
+        };
+      });
+    } catch (err) {
+      console.warn("FTS search failed, falling back to LIKE", err);
+      mode = "basic";
+    }
+  } else {
+    mode = "basic";
+  }
+
+  if (mode === "basic") {
+    const fallbackRows = await all(
+      `
+      SELECT DISTINCT
+        p.title,
+        p.slug_id,
+        substr(p.content, 1, 400) AS excerpt,
+        (
+          SELECT GROUP_CONCAT(t2.name, ',')
+          FROM tags t2
+          JOIN page_tags pt2 ON pt2.tag_id = t2.id
+          WHERE pt2.page_id = p.id
+        ) AS tagsCsv
+      FROM pages p
+      LEFT JOIN page_tags pt ON pt.page_id = p.id
+      LEFT JOIN tags t ON t.id = pt.tag_id
+      WHERE p.title   LIKE '%'||?||'%'
+         OR p.content LIKE '%'||?||'%'
+         OR t.name    LIKE '%'||?||'%'
+      ORDER BY p.updated_at DESC, p.created_at DESC
+      LIMIT 100
+    `,
+      [q, q, q],
+    );
+    rows = fallbackRows.map((row) => ({ ...row, snippet: null, score: null }));
+  }
+
+  res.render("search", { q, rows, mode, ftsAvailable: ftsPossible });
 });
 
 export default r;
+
+function tokenize(input) {
+  return input
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter(Boolean)
+    .map((term) => term.toLowerCase().replace(/[^\p{L}\p{N}]/gu, ""))
+    .filter(Boolean);
+}
+
+function chooseSnippet(row) {
+  const snippets = [row.contentSnippet, row.tagsSnippet];
+  for (const s of snippets) {
+    if (s && s.trim()) {
+      return s;
+    }
+  }
+  return row.excerpt || "";
+}

--- a/views/search.ejs
+++ b/views/search.ejs
@@ -1,20 +1,33 @@
 <% title = 'Recherche'; %>
 <h1>Résultats pour « <%= q %> »</h1>
 
+<% if (mode !== 'fts') { %>
+  <p><em>Recherche basique utilisée car l’index plein texte <% if (!ftsAvailable) { %>n’est pas disponible<% } else { %>n’a pas pu être utilisé pour cette requête<% } %>.</em></p>
+<% } %>
+
 <div class="article-grid">
   <% if (!rows.length) { %>
     <div class="card">Aucun résultat.</div>
   <% } %>
 
-  <% rows.forEach(p => { 
+  <% rows.forEach(p => {
        const tags = (p.tagsCsv || '').split(',').filter(Boolean);
+       const showScore = mode === 'fts' && Number.isFinite(p.score);
   %>
     <div class="card">
       <h3><strong><%= p.title %></strong></h3>
-      <% if (p.excerpt) { %>
+      <% if (p.snippet) { %>
+        <div class="excerpt">
+          <div class="excerpt-body"><%- p.snippet %></div>
+        </div>
+      <% } else if (p.excerpt) { %>
         <div class="excerpt">
           <div class="excerpt-body"><%- p.excerpt %></div>
         </div>
+      <% } %>
+
+      <% if (showScore) { %>
+        <div class="meta">Score BM25 : <%= p.score.toFixed(2) %></div>
       <% } %>
 
       <% if (tags.length) { %>


### PR DESCRIPTION
## Summary
- add an FTS5-backed `pages_fts` virtual table and helpers to keep it in sync with `pages`
- update page creation, editing, and deletion flows to maintain the search index
- implement full-text search with highlighted snippets and a graceful fallback when FTS is unavailable

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68d7e64f41788321869017d138250e9f