### PR TITLE
Log admin and auth actions to Discord

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,25 +1,76 @@
 import { Router } from "express";
 import { get, run } from "../db.js";
 import { hashPassword, isBcryptHash, verifyPassword } from "../utils/passwords.js";
+import { sendAdminEvent } from "../utils/webhook.js";
+import { getClientIp } from "../utils/ip.js";
 
 const r = Router();
 
 r.get("/login", (req, res) => res.render("login"));
 r.post("/login", async (req, res) => {
   const { username, password } = req.body;
+  const ip = getClientIp(req);
   const u = await get("SELECT * FROM users WHERE username=?", [username]);
-  if (!u) return res.render("login", { error: "Identifiants invalides" });
+  if (!u) {
+    await sendAdminEvent(
+      "Connexion échouée",
+      {
+        user: username,
+        extra: {
+          ip,
+          reason: "Utilisateur inconnu",
+        },
+      },
+      { includeScreenshot: false },
+    );
+    return res.render("login", { error: "Identifiants invalides" });
+  }
   const storedHash = u.password;
   const ok = await verifyPassword(password, storedHash);
-  if (!ok) return res.render("login", { error: "Identifiants invalides" });
+  if (!ok) {
+    await sendAdminEvent(
+      "Connexion échouée",
+      {
+        user: username,
+        extra: {
+          ip,
+          reason: "Mot de passe invalide",
+        },
+      },
+      { includeScreenshot: false },
+    );
+    return res.render("login", { error: "Identifiants invalides" });
+  }
   if (!isBcryptHash(storedHash)) {
     const newHash = await hashPassword(password);
     await run("UPDATE users SET password=? WHERE id=?", [newHash, u.id]);
   }
   req.session.user = { id: u.id, username: u.username, is_admin: !!u.is_admin };
+  await sendAdminEvent(
+    "Connexion réussie",
+    {
+      user: u.username,
+      extra: {
+        ip,
+      },
+    },
+    { includeScreenshot: false },
+  );
   res.redirect("/");
 });
-r.post("/logout", (req, res) => {
+r.post("/logout", async (req, res) => {
+  const username = req.session?.user?.username || null;
+  const ip = getClientIp(req);
+  await sendAdminEvent(
+    "Déconnexion",
+    {
+      user: username,
+      extra: {
+        ip,
+      },
+    },
+    { includeScreenshot: false },
+  );
   req.session.destroy(() => res.redirect("/"));
 });
 


### PR DESCRIPTION
## Summary
- notify Discord webhooks for login attempts and logouts with contextual metadata
- extend admin actions (imports, uploads, settings, user and like management) to send detailed webhook events including actor IPs

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d7f1ee257c8321853db8d8a4641160