### PR TITLE
Add pagination to admin events log

### DIFF
--- a/views/admin/events.ejs
+++ b/views/admin/events.ejs
@@ -38,5 +38,20 @@
         </tbody>
       </table>
     </div>
+    <div class="table-footer" style="display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:0.5rem; margin-top:1rem;">
+      <span>Page <%= pagination.page %> sur <%= pagination.totalPages %></span>
+      <div style="display:flex; gap:0.5rem;">
+        <% if (pagination.hasPrevious) { %>
+          <a class="btn" href="?page=<%= pagination.previousPage %>">Précédent</a>
+        <% } else { %>
+          <span class="btn" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Précédent</span>
+        <% } %>
+        <% if (pagination.hasNext) { %>
+          <a class="btn" href="?page=<%= pagination.nextPage %>">Suivant</a>
+        <% } else { %>
+          <span class="btn" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Suivant</span>
+        <% } %>
+      </div>
+    </div>
   <% } %>
 </section>


### PR DESCRIPTION
## Summary
- add pagination support to the admin events route with limit/offset queries and page validation
- pass pagination metadata to the events view and render previous/next controls

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d801b97f60832192363a0112701541