### PR TITLE
Handle JSON parsing for admin events

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -867,8 +867,36 @@ r.get("/events", async (req, res) => {
     [pageSize, offset],
   );
 
+  const viewEvents = events.map((event) => {
+    const rawPayload =
+      typeof event.payload === "string" ? event.payload.trim() : "";
+    if (!rawPayload) {
+      return {
+        ...event,
+        payloadPretty: "{}",
+        payloadParseError: false,
+      };
+    }
+
+    try {
+      const parsed = JSON.parse(rawPayload);
+      return {
+        ...event,
+        payloadPretty: JSON.stringify(parsed, null, 2),
+        payloadParseError: false,
+        payloadObject: parsed,
+      };
+    } catch (error) {
+      return {
+        ...event,
+        payloadPretty: event.payload,
+        payloadParseError: true,
+      };
+    }
+  });
+
   res.render("admin/events", {
-    events,
+    events: viewEvents,
     pagination: {
       page,
       totalPages,

--- a/views/admin/events.ejs
+++ b/views/admin/events.ejs
@@ -29,8 +29,13 @@
               <td><%= ev.ip || '-' %></td>
               <td><%= new Date(ev.created_at).toLocaleString('fr-FR') %></td>
               <td style="max-width:320px;">
+                <% if (ev.payloadParseError) { %>
+                  <p style="color:#f87171; font-size:0.75em; margin:0 0 0.25rem 0;">
+                    Impossible d'analyser le JSON, affichage brut.
+                  </p>
+                <% } %>
                 <pre style="white-space:pre-wrap; word-break:break-word; font-size:0.8em; background:rgba(15,23,42,0.7); padding:8px; border-radius:8px;">
-<%= ev.payload || '{}' %>
+<%= ev.payloadPretty || '{}' %>
                 </pre>
               </td>
             </tr>


### PR DESCRIPTION
## Summary
- parse admin event payloads safely and generate a prettified representation
- expose parse failures to the template so errors can be indicated to admins
- update the events view to display formatted JSON or highlight parsing issues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d802a8aa3883219c70f00d03c3699f