### PR TITLE
Generate article screenshots for feed webhooks

### DIFF
--- a/routes/pages.js
+++ b/routes/pages.js
@@ -130,12 +130,16 @@ r.post(
       page: { title, slug_id, slug_base: base },
       extra: { tags },
     });
-    await sendFeedEvent("Nouvel article", {
-      page: { title, slug_id },
-      author: req.session.user?.username,
-      url: req.protocol + "://" + req.get("host") + "/wiki/" + slug_id,
-      tags,
-    });
+    await sendFeedEvent(
+      "Nouvel article",
+      {
+        page: { title, slug_id },
+        author: req.session.user?.username,
+        url: req.protocol + "://" + req.get("host") + "/wiki/" + slug_id,
+        tags,
+      },
+      { articleContent: content },
+    );
     res.redirect("/wiki/" + slug_id);
   }),
 );


### PR DESCRIPTION
## Summary
- stop attaching generic screenshots to all webhook payloads and support explicit attachments
- capture and attach a styled article preview image when publishing the "Nouvel article" feed webhook
- pass the freshly created article content through webhook options without polluting stored payload metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80a31aed08321a96717849c323d51