### PR TITLE
Fix event log detail visibility and feed screenshot rendering

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -867,36 +867,8 @@ r.get("/events", async (req, res) => {
     [pageSize, offset],
   );
 
-  const viewEvents = events.map((event) => {
-    const rawPayload =
-      typeof event.payload === "string" ? event.payload.trim() : "";
-    if (!rawPayload) {
-      return {
-        ...event,
-        payloadPretty: "{}",
-        payloadParseError: false,
-      };
-    }
-
-    try {
-      const parsed = JSON.parse(rawPayload);
-      return {
-        ...event,
-        payloadPretty: JSON.stringify(parsed, null, 2),
-        payloadParseError: false,
-        payloadObject: parsed,
-      };
-    } catch (error) {
-      return {
-        ...event,
-        payloadPretty: event.payload,
-        payloadParseError: true,
-      };
-    }
-  });
-
   res.render("admin/events", {
-    events: viewEvents,
+    events,
     pagination: {
       page,
       totalPages,

--- a/utils/screenshot.js
+++ b/utils/screenshot.js
@@ -65,6 +65,10 @@ export async function renderEventScreenshot(title, data) {
 function sanitizeContent(content) {
   if (!content) return "";
   return String(content)
+    .replace(/<\s*br\s*\/?\s*>/gi, "\n")
+    .replace(/<\s*\/p\s*>/gi, "\n\n")
+    .replace(/<\s*\/h[1-6]\s*>/gi, "\n\n")
+    .replace(/<[^>]+>/g, "")
     .replace(/```[\s\S]*?```/g, "")
     .replace(/!\[[^\]]*\]\([^\)]+\)/g, "")
     .replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1")

--- a/views/admin/events.ejs
+++ b/views/admin/events.ejs
@@ -16,7 +16,6 @@
             <th>Utilisateur</th>
             <th>IP</th>
             <th>Date</th>
-            <th>Détails</th>
           </tr>
         </thead>
         <tbody>
@@ -28,16 +27,6 @@
               <td><%= ev.username || '-' %></td>
               <td><%= ev.ip || '-' %></td>
               <td><%= new Date(ev.created_at).toLocaleString('fr-FR') %></td>
-              <td style="max-width:320px;">
-                <% if (ev.payloadParseError) { %>
-                  <p style="color:#f87171; font-size:0.75em; margin:0 0 0.25rem 0;">
-                    Impossible d'analyser le JSON, affichage brut.
-                  </p>
-                <% } %>
-                <pre style="white-space:pre-wrap; word-break:break-word; font-size:0.8em; background:rgba(15,23,42,0.7); padding:8px; border-radius:8px;">
-<%= ev.payloadPretty || '{}' %>
-                </pre>
-              </td>
             </tr>
           <% }) %>
         </tbody>


### PR DESCRIPTION
## Summary
- hide the payload column from the admin event log to avoid surfacing detailed webhook data
- improve feed webhook screenshots by stripping HTML tags and preserving spacing when building the article preview

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d80d34d07c832195bb072062edf0b6