### PR TITLE
feat: externalize session configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,37 @@
   <code>npm run db:init</code> with a bcrypt-hashed password). Change it after
   the first login.
 </p>
+
+<h2>Configuration</h2>
+
+<p>
+  The application reads session secrets and cookie settings from environment
+  variables so that sensitive values never need to be committed to source
+  control.
+</p>
+
+<ul>
+  <li>
+    <code>SESSION_SECRET</code> / <code>SESSION_SECRETS</code> – provide one or
+    more secrets (comma separated) used to sign the session cookies. Multiple
+    secrets allow for a smooth rotation window.
+  </li>
+  <li>
+    <code>SESSION_SECRET_FILE</code> – optional path to a file containing secrets
+    (one per line). The file is watched for changes so a new value takes effect
+    without restarting the server.
+  </li>
+  <li>
+    <code>SESSION_COOKIE_*</code> – tweak cookie behaviour. Supported suffixes
+    are <code>NAME</code>, <code>SECURE</code>, <code>HTTP_ONLY</code>,
+    <code>SAMESITE</code>, <code>MAX_AGE</code> and <code>ROLLING</code>.
+  </li>
+</ul>
+
+<p>
+  When no secret is provided a development-only fallback is used and a warning
+  is printed. Always configure a strong secret for production.
+</p>
 <p>
   Plain-text passwords created before the bcrypt migration are automatically
   re-hashed on the next successful login. Communicate to existing users that a

--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ import path from "path";
 import expressLayouts from "express-ejs-layouts";
 import { fileURLToPath } from "url";
 import { initDb, get, run } from "./db.js";
+import { sessionConfig } from "./utils/config.js";
 import authRoutes from "./routes/auth.js";
 import adminRoutes from "./routes/admin.js";
 import pagesRoutes from "./routes/pages.js";
@@ -27,13 +28,7 @@ app.use(methodOverride("_method"));
 app.use(morgan("dev"));
 app.use("/public", express.static(path.join(__dirname, "public")));
 
-app.use(
-  session({
-    secret: "change-me",
-    resave: false,
-    saveUninitialized: false,
-  }),
-);
+app.use(session(sessionConfig));
 
 // expose user + settings to views
 app.use(async (req, res, next) => {

--- a/utils/config.js
+++ b/utils/config.js
@@ -1,0 +1,47 @@
+import { getSessionSecrets } from "./sessionSecrets.js";
+
+function booleanFromEnv(value) {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}
+
+const cookieConfig = {};
+const cookieSecure = booleanFromEnv(process.env.SESSION_COOKIE_SECURE);
+const cookieHttpOnly = booleanFromEnv(process.env.SESSION_COOKIE_HTTP_ONLY);
+const cookieSameSite = process.env.SESSION_COOKIE_SAMESITE;
+const cookieMaxAge = process.env.SESSION_COOKIE_MAX_AGE
+  ? Number(process.env.SESSION_COOKIE_MAX_AGE)
+  : undefined;
+
+if (cookieSecure !== undefined) {
+  cookieConfig.secure = cookieSecure;
+}
+if (cookieHttpOnly !== undefined) {
+  cookieConfig.httpOnly = cookieHttpOnly;
+}
+if (cookieSameSite) {
+  cookieConfig.sameSite = cookieSameSite;
+}
+if (!Number.isNaN(cookieMaxAge) && cookieMaxAge !== undefined) {
+  cookieConfig.maxAge = cookieMaxAge;
+}
+
+export const sessionConfig = {
+  secret: getSessionSecrets(),
+  resave: false,
+  saveUninitialized: false,
+};
+
+if (Object.keys(cookieConfig).length > 0) {
+  sessionConfig.cookie = cookieConfig;
+}
+
+if (process.env.SESSION_COOKIE_NAME) {
+  sessionConfig.name = process.env.SESSION_COOKIE_NAME;
+}
+
+if (booleanFromEnv(process.env.SESSION_COOKIE_ROLLING)) {
+  sessionConfig.rolling = true;
+}

--- a/utils/sessionSecrets.js
+++ b/utils/sessionSecrets.js
@@ -1,0 +1,95 @@
+import fs from "fs";
+
+const activeSecrets = [];
+let watcher;
+let debounceTimer;
+
+const DEFAULT_SECRET = "development-secret";
+
+function normalizeSecretList(list) {
+  return list
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function readSecretsFromFile(filePath) {
+  try {
+    const fileContents = fs.readFileSync(filePath, "utf8");
+    return normalizeSecretList(fileContents.split(/\r?\n/));
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      console.warn("Unable to read session secret file:", error.message);
+    }
+    return [];
+  }
+}
+
+function readSecretsFromEnv() {
+  const secrets = [];
+  if (process.env.SESSION_SECRET) {
+    secrets.push(process.env.SESSION_SECRET);
+  }
+  if (process.env.SESSION_SECRETS) {
+    secrets.push(...process.env.SESSION_SECRETS.split(","));
+  }
+  return normalizeSecretList(secrets);
+}
+
+function ensureSecretsLoaded(values) {
+  const unique = Array.from(new Set(values));
+  if (unique.length === 0) {
+    console.warn(
+      "No session secret provided. Falling back to an insecure development secret.",
+    );
+    unique.push(DEFAULT_SECRET);
+  }
+  activeSecrets.splice(0, activeSecrets.length, ...unique);
+  return activeSecrets;
+}
+
+export function refreshSessionSecrets() {
+  const fromEnv = readSecretsFromEnv();
+  const filePath = process.env.SESSION_SECRET_FILE;
+  const fromFile = filePath ? readSecretsFromFile(filePath) : [];
+  return ensureSecretsLoaded([...fromEnv, ...fromFile]);
+}
+
+export function getSessionSecrets() {
+  if (!activeSecrets.length) {
+    refreshSessionSecrets();
+  }
+  return activeSecrets;
+}
+
+function setupWatchers() {
+  const filePath = process.env.SESSION_SECRET_FILE;
+  if (!filePath || watcher) {
+    return;
+  }
+
+  try {
+    watcher = fs.watch(filePath, { persistent: false }, (eventType) => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        refreshSessionSecrets();
+        console.info("Session secrets reloaded from", filePath);
+        if (eventType === "rename") {
+          watcher.close();
+          watcher = undefined;
+          setupWatchers();
+        }
+      }, 100);
+    });
+  } catch (error) {
+    watcher = undefined;
+    console.warn("Failed to watch session secret file:", error.message);
+  }
+}
+
+refreshSessionSecrets();
+setupWatchers();
+
+process.on("SIGHUP", () => {
+  refreshSessionSecrets();
+  console.info("Session secrets reloaded after SIGHUP signal");
+});


### PR DESCRIPTION
## Summary
- load session secrets from environment variables and optional on-disk sources for rotation
- centralize session middleware configuration with cookie-related toggles
- document the new environment variables in the README

## Testing
- node -e "import('./utils/sessionSecrets.js').then((module) => { console.log(module.getSessionSecrets()); }).catch((err) => { console.error(err); process.exit(1); })"


------
https://chatgpt.com/codex/tasks/task_e_68d815e863248321b35664227c61bb6a