### PR TITLE
feat: refresh button styling with animated emojis

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -80,26 +80,35 @@ body {
 
 /* === BUTTONS === */
 .btn {
+  --btn-start: #6366f1;
+  --btn-end: #8b5cf6;
+  --btn-text: #f8fafc;
+  --btn-shadow: rgba(99, 102, 241, 0.28);
+  --btn-shadow-hover: rgba(99, 102, 241, 0.4);
+  --btn-shadow-active: rgba(99, 102, 241, 0.24);
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
   min-height: 42px;
-  padding: 0 1.1rem;
-  border-radius: 12px;
+  padding: 0 1.2rem;
+  border-radius: 14px;
   border: 0;
-  background: linear-gradient(135deg, #4f46e5, #7c3aed);
-  color: #f8fafc;
+  background: linear-gradient(135deg, var(--btn-start), var(--btn-end));
+  background-size: 180% 180%;
+  background-position: 0% 50%;
+  color: var(--btn-text);
   line-height: 1.1;
   font-weight: 600;
   letter-spacing: 0.01em;
   cursor: pointer;
   transition:
-    transform 150ms ease,
+    transform 160ms cubic-bezier(0.22, 1, 0.36, 1),
     box-shadow 220ms ease,
-    background 240ms ease;
-  box-shadow: 0 14px 28px rgba(79, 70, 229, 0.22);
+    background-position 260ms ease,
+    filter 220ms ease;
+  box-shadow: 0 14px 28px var(--btn-shadow);
   overflow: hidden;
   isolation: isolate;
 }
@@ -108,35 +117,39 @@ body {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.25), transparent 60%);
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.2), transparent 60%),
+    radial-gradient(circle at bottom right, rgba(15, 23, 42, 0.2), transparent 70%);
   opacity: 0;
   transform: scale(0.9);
   transition:
     opacity 220ms ease,
-    transform 240ms ease;
+    transform 260ms ease;
   z-index: -1;
 }
 .btn:hover {
   transform: translateY(-2px);
-  box-shadow: 0 18px 32px rgba(79, 70, 229, 0.32);
+  box-shadow: 0 18px 36px var(--btn-shadow-hover);
+  background-position: 90% 50%;
 }
 .btn:hover::after {
   opacity: 1;
-  transform: scale(1.05);
+  transform: scale(1.08);
 }
 .btn:active {
   transform: translateY(1px) scale(0.97);
-  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.28);
+  box-shadow: 0 8px 20px var(--btn-shadow-active);
+  background-position: 10% 70%;
 }
 .btn:active::after {
-  opacity: 0.8;
-  transform: scale(0.92);
+  opacity: 0.85;
+  transform: scale(0.94);
 }
 .btn[disabled],
 .btn:disabled,
 .btn[aria-disabled="true"] {
   cursor: not-allowed;
-  opacity: 0.65;
+  opacity: 0.6;
   transform: none !important;
   box-shadow: none !important;
 }
@@ -151,7 +164,7 @@ body {
   font-size: 1.15rem;
   margin-right: 0.45rem;
   filter: drop-shadow(0 4px 8px rgba(15, 17, 21, 0.3));
-  transition: transform 200ms ease;
+  transition: transform 220ms ease;
 }
 .btn[data-icon]:hover::before {
   transform: translateY(-1px) scale(1.08);
@@ -160,59 +173,92 @@ body {
   transform: translateY(0) scale(0.94);
 }
 .btn.secondary {
-  background: linear-gradient(135deg, #cbd5f5, #94a3b8);
-  color: #0f172a;
-  box-shadow: 0 14px 26px rgba(148, 163, 184, 0.28);
-}
-.btn.secondary:hover {
-  box-shadow: 0 18px 32px rgba(148, 163, 184, 0.36);
-}
-.btn.secondary:active {
-  box-shadow: 0 10px 18px rgba(148, 163, 184, 0.32);
+  --btn-start: #e2e8f0;
+  --btn-end: #cbd5f5;
+  --btn-text: #0f172a;
+  --btn-shadow: rgba(148, 163, 184, 0.38);
+  --btn-shadow-hover: rgba(148, 163, 184, 0.48);
+  --btn-shadow-active: rgba(148, 163, 184, 0.32);
 }
 .btn.danger {
-  background: linear-gradient(135deg, #f97316, #ef4444);
-  color: #fff7ed;
-  box-shadow: 0 14px 28px rgba(239, 68, 68, 0.25);
+  --btn-start: #fb7185;
+  --btn-end: #dc2626;
+  --btn-text: #fff5f5;
+  --btn-shadow: rgba(220, 38, 38, 0.32);
+  --btn-shadow-hover: rgba(220, 38, 38, 0.42);
+  --btn-shadow-active: rgba(220, 38, 38, 0.28);
 }
 .btn.success {
-  background: linear-gradient(135deg, #34d399, #059669);
-  color: #022c22;
-  box-shadow: 0 14px 28px rgba(34, 197, 94, 0.22);
+  --btn-start: #34d399;
+  --btn-end: #059669;
+  --btn-text: #022c22;
+  --btn-shadow: rgba(34, 197, 94, 0.32);
+  --btn-shadow-hover: rgba(34, 197, 94, 0.42);
+  --btn-shadow-active: rgba(34, 197, 94, 0.28);
 }
 .btn.copy,
 .btn.copy-upload {
-  background: linear-gradient(135deg, #60a5fa, #2563eb);
-  color: #f8fafc;
-  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.25);
+  --btn-start: #38bdf8;
+  --btn-end: #2563eb;
+  --btn-text: #f8fafc;
+  --btn-shadow: rgba(37, 99, 235, 0.3);
+  --btn-shadow-hover: rgba(37, 99, 235, 0.42);
+  --btn-shadow-active: rgba(37, 99, 235, 0.26);
 }
 .btn.like {
-  background: linear-gradient(135deg, #22c55e, #16a34a);
-  color: #022c22;
-  box-shadow: 0 14px 28px rgba(34, 197, 94, 0.24);
+  --btn-start: #f472b6;
+  --btn-end: #db2777;
+  --btn-text: #fff5f8;
+  --btn-shadow: rgba(236, 72, 153, 0.3);
+  --btn-shadow-hover: rgba(236, 72, 153, 0.42);
+  --btn-shadow-active: rgba(236, 72, 153, 0.26);
 }
 .btn.unlike {
-  background: linear-gradient(135deg, #f87171, #dc2626);
-  color: #fef2f2;
-  box-shadow: 0 14px 28px rgba(220, 38, 38, 0.24);
+  --btn-start: #fb7185;
+  --btn-end: #b91c1c;
+  --btn-text: #fff1f2;
+  --btn-shadow: rgba(190, 18, 60, 0.32);
+  --btn-shadow-hover: rgba(190, 18, 60, 0.44);
+  --btn-shadow-active: rgba(190, 18, 60, 0.26);
 }
 .btn.search {
-  background: linear-gradient(135deg, #fbbf24, #f59e0b);
-  color: #172554;
-  box-shadow: 0 14px 28px rgba(245, 158, 11, 0.26);
+  --btn-start: #facc15;
+  --btn-end: #f97316;
+  --btn-text: #1f2937;
+  --btn-shadow: rgba(245, 158, 11, 0.32);
+  --btn-shadow-hover: rgba(245, 158, 11, 0.44);
+  --btn-shadow-active: rgba(245, 158, 11, 0.28);
 }
 .btn.icon.only {
+  --btn-start: rgba(42, 48, 66, 0.8);
+  --btn-end: rgba(42, 48, 66, 0.8);
+  --btn-text: #f1f5f9;
+  --btn-shadow: rgba(15, 23, 42, 0.24);
+  --btn-shadow-hover: rgba(15, 23, 42, 0.32);
+  --btn-shadow-active: rgba(15, 23, 42, 0.2);
   min-width: 36px;
   padding: 0 0.5rem;
   font-size: 18px;
   line-height: 1;
   display: none;
-  background: rgba(42, 48, 66, 0.7);
   box-shadow: none;
 }
 .btn.icon.only::after,
 .btn.icon.only::before {
   content: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn,
+  .btn::after,
+  .btn[data-icon]::before {
+    transition: none !important;
+  }
+  .btn:hover,
+  .btn:active {
+    transform: none !important;
+    background-position: 50% 50% !important;
+  }
 }
 
 @media (max-width: 820px) {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -19,9 +19,9 @@
         <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
         <form action="/wiki/<%= p.slug_id %>/like" method="post">
           <% if (p.userLiked) { %>
-            <button class="btn unlike">❌ Retirer (<%= p.likes %>)</button>
+            <button class="btn unlike" data-icon="💔">Retirer (<%= p.likes %>)</button>
           <% } else { %>
-            <button class="btn like">👍 Like (<%= p.likes %>)</button>
+            <button class="btn like" data-icon="💖">Like (<%= p.likes %>)</button>
           <% } %>
         </form>
         <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')">Copier le lien</button>
@@ -59,9 +59,9 @@
         <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
         <form action="/wiki/<%= p.slug_id %>/like" method="post">
           <% if (p.userLiked) { %>
-            <button class="btn unlike">❌ Retirer (<%= p.likes %>)</button>
+            <button class="btn unlike" data-icon="💔">Retirer (<%= p.likes %>)</button>
           <% } else { %>
-            <button class="btn like">👍 Like (<%= p.likes %>)</button>
+            <button class="btn like" data-icon="💖">Like (<%= p.likes %>)</button>
           <% } %>
         </form>
         <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')">Copier le lien</button>

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -12,9 +12,9 @@
   <div class="actions">
     <form action="/wiki/<%= page.slug_id %>/like" method="post">
       <% if (page.userLiked) { %>
-        <button class="btn unlike">❌ Retirer le like (<%= page.likes %>)</button>
+        <button class="btn unlike" data-icon="💔">Retirer le like (<%= page.likes %>)</button>
       <% } else { %>
-        <button class="btn like">👍 Like (<%= page.likes %>)</button>
+        <button class="btn like" data-icon="💖">Like (<%= page.likes %>)</button>
       <% } %>
     </form>
     <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= page.slug_id %>')">Copier le lien</button>

--- a/views/tags.ejs
+++ b/views/tags.ejs
@@ -19,9 +19,9 @@
         <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
         <form action="/wiki/<%= p.slug_id %>/like" method="post">
           <% if (p.userLiked) { %>
-            <button class="btn unlike">❌ Retirer (<%= p.likes %>)</button>
+            <button class="btn unlike" data-icon="💔">Retirer (<%= p.likes %>)</button>
           <% } else { %>
-            <button class="btn like">👍 Like (<%= p.likes %>)</button>
+            <button class="btn like" data-icon="💖">Like (<%= p.likes %>)</button>
           <% } %>
         </form>
         <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')">Copier le lien</button>


### PR DESCRIPTION
## Summary
- restyled the shared button component with gradient color variables, animated hover/click states, and reduced-motion handling
- added consistent emoji icons to the like/unlike actions across article lists and detail pages

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d83e03faa48321ba4d380f657c8c8e