### PR TITLE
Fix rich text editor submission and restore button icons

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -23,8 +23,28 @@
 
 document.addEventListener("DOMContentLoaded", () => {
   initNotifications();
+  enhanceIconButtons();
   initHtmlEditor();
 });
+
+function enhanceIconButtons() {
+  document.querySelectorAll(".btn[data-icon]").forEach((btn) => {
+    if (btn.querySelector(".btn-icon")) {
+      return;
+    }
+
+    const icon = btn.getAttribute("data-icon");
+    if (!icon) {
+      return;
+    }
+
+    const iconSpan = document.createElement("span");
+    iconSpan.className = "btn-icon";
+    iconSpan.setAttribute("aria-hidden", "true");
+    iconSpan.textContent = icon;
+    btn.prepend(iconSpan);
+  });
+}
 
 function initNotifications() {
   const layer = document.getElementById("notificationLayer");
@@ -134,6 +154,7 @@ function initHtmlEditor() {
 
   if (!window.Quill) {
     field.hidden = false;
+    field.removeAttribute("hidden");
     container.style.display = "none";
     const toolbar = toolbarSelector ? document.querySelector(toolbarSelector) : null;
     if (toolbar) {
@@ -142,7 +163,14 @@ function initHtmlEditor() {
     return;
   }
 
-  const options = { theme: "snow", modules: {} };
+  const options = {
+    theme: "snow",
+    modules: {
+      clipboard: {
+        matchVisual: false,
+      },
+    },
+  };
   if (toolbarSelector) {
     options.modules.toolbar = toolbarSelector;
   }
@@ -153,10 +181,24 @@ function initHtmlEditor() {
     quill.clipboard.dangerouslyPasteHTML(initialValue);
   }
 
+  const syncField = () => {
+    const html = quill.root.innerHTML.trim();
+    const text = quill.getText().trim();
+    if (!text) {
+      field.value = "";
+    } else {
+      field.value = html;
+    }
+  };
+
+  syncField();
+
+  quill.on("text-change", syncField);
+
   const form = field.form;
   if (form) {
     form.addEventListener("submit", () => {
-      field.value = quill.root.innerHTML.trim();
+      syncField();
     });
   }
 }

--- a/public/style.css
+++ b/public/style.css
@@ -159,17 +159,19 @@ body {
   opacity: 0.2;
   transform: scale(1);
 }
-.btn[data-icon]::before {
-  content: attr(data-icon);
+.btn .btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-size: 1.15rem;
   margin-right: 0.45rem;
   filter: drop-shadow(0 4px 8px rgba(15, 17, 21, 0.3));
   transition: transform 220ms ease;
 }
-.btn[data-icon]:hover::before {
+.btn:hover .btn-icon {
   transform: translateY(-1px) scale(1.08);
 }
-.btn[data-icon]:active::before {
+.btn:active .btn-icon {
   transform: translateY(0) scale(0.94);
 }
 .btn.secondary {

--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -8,16 +8,25 @@
   <div class="html-editor-shell">
     <div class="html-editor-toolbar" id="editorToolbar">
       <span class="ql-formats">
+        <select class="ql-header" aria-label="Niveau de titre">
+          <option selected></option>
+          <option value="2">Titre moyen</option>
+          <option value="3">Sous-titre</option>
+        </select>
         <button class="ql-bold" aria-label="Gras"></button>
         <button class="ql-italic" aria-label="Italique"></button>
         <button class="ql-underline" aria-label="Souligné"></button>
+        <button class="ql-strike" aria-label="Barré"></button>
       </span>
       <span class="ql-formats">
         <button class="ql-list" value="ordered" aria-label="Liste numérotée"></button>
         <button class="ql-list" value="bullet" aria-label="Liste à puces"></button>
+        <button class="ql-blockquote" aria-label="Bloc de citation"></button>
+        <button class="ql-code-block" aria-label="Bloc de code"></button>
       </span>
       <span class="ql-formats">
         <button class="ql-link" aria-label="Insérer un lien"></button>
+        <button class="ql-image" aria-label="Insérer une image"></button>
         <button class="ql-clean" aria-label="Effacer la mise en forme"></button>
       </span>
     </div>
@@ -35,7 +44,7 @@
   <label>Tags (séparés par des virgules)</label>
   <input type="text" name="tags" value="<%= tags %>" />
   <div class="actions">
-    <button class="btn success" data-icon="💾">Enregistrer</button>
+    <button class="btn success" data-icon="💾" type="submit">Enregistrer</button>
   </div>
 </form>
 


### PR DESCRIPTION
## Summary
- restore button emoji rendering by injecting dedicated icon spans and styling
- expand the rich text editor toolbar while keeping the textarea synchronized with Quill
- fall back to the plain textarea when the editor bundle is unavailable

## Testing
- npm start (manual verification; created and saved pages through the HTML editor)


------
https://chatgpt.com/codex/tasks/task_e_68d8438084dc832198a6d6ed7bc228c2