### PR TITLE
Fix admin comment deletion form to avoid 404

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -144,7 +144,7 @@ r.post("/comments/:id/reject", async (req, res) => {
   res.redirect("/admin/comments");
 });
 
-r.delete("/comments/:id", async (req, res) => {
+async function handleCommentDeletion(req, res) {
   const comment = await get(
     `SELECT c.id, c.snowflake_id, c.ip, p.title, p.slug_id
        FROM comments c
@@ -169,7 +169,10 @@ r.delete("/comments/:id", async (req, res) => {
     extra: { ip: comment.ip, commentId: comment.snowflake_id },
   });
   res.redirect("/admin/comments");
-});
+}
+
+r.delete("/comments/:id", handleCommentDeletion);
+r.post("/comments/:id/delete", handleCommentDeletion);
 
 r.get("/ip-bans", async (req, res) => {
   const bans = await all(

--- a/views/admin/comments.ejs
+++ b/views/admin/comments.ejs
@@ -33,8 +33,7 @@
             <form method="post" action="/admin/comments/<%= c.snowflake_id %>/reject">
               <button class="btn" data-icon="🚫" type="submit">Rejeter</button>
             </form>
-            <form method="post" action="/admin/comments/<%= c.snowflake_id %>" onsubmit="return confirm('Supprimer ce commentaire ?');">
-              <input type="hidden" name="_method" value="DELETE">
+            <form method="post" action="/admin/comments/<%= c.snowflake_id %>/delete" onsubmit="return confirm('Supprimer ce commentaire ?');">
               <button class="btn unlike" data-icon="🗑️" type="submit">Supprimer</button>
             </form>
           </div>


### PR DESCRIPTION
## Summary
- refactor the admin comment deletion logic into a reusable handler
- add a POST /admin/comments/:id/delete endpoint and point the form to it to avoid 404s

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68d992b049d08321aaad064ab7b4125d