### PR TITLE
Enhance notification coverage and admin moderation tools

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -533,11 +533,14 @@ form .actions {
 .data-table th,
 .data-table td {
   white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  max-width: 320px;
   padding: 12px 14px;
   border-bottom: 1px solid #242a36;
+}
+
+.data-table th code,
+.data-table td code {
+  white-space: nowrap;
+  overflow: visible;
 }
 .data-table thead th {
   position: sticky;
@@ -872,8 +875,6 @@ code {
   .data-table th,
   .data-table td {
     white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
   }
 }
 

--- a/views/admin/comments.ejs
+++ b/views/admin/comments.ejs
@@ -1,11 +1,5 @@
 <h1>Modération des commentaires</h1>
 
-<% if (notice) { %>
-  <div class="card" style="padding:16px; margin-bottom:20px; border:1px solid <%= notice.type === 'error' ? '#f87171' : '#4ade80' %>; background:<%= notice.type === 'error' ? 'rgba(248,113,113,0.15)' : 'rgba(74,222,128,0.12)' %>; border-radius:12px;">
-    <strong><%= notice.message %></strong>
-  </div>
-<% } %>
-
 <section class="card" style="margin-bottom:24px;">
   <h2 style="margin-top:0;">En attente de validation (<%= pending.length %>)</h2>
   <% if (!pending.length) { %>
@@ -63,6 +57,11 @@
           <% if (c.updated_at) { %>
             <p class="meta">Dernière modification : <%= new Date(c.updated_at).toLocaleString('fr-FR') %></p>
           <% } %>
+          <div class="actions">
+            <form method="post" action="/admin/comments/<%= c.snowflake_id %>/delete" onsubmit="return confirm('Supprimer ce commentaire ?');">
+              <button class="btn unlike" data-icon="🗑️" type="submit">Supprimer</button>
+            </form>
+          </div>
         </li>
       <% }) %>
     </ul>

--- a/views/admin/ip_bans.ejs
+++ b/views/admin/ip_bans.ejs
@@ -3,11 +3,6 @@
 
 <section class="card" style="margin-bottom:24px;">
   <h2>Ajouter un blocage</h2>
-  <% if (notice) { %>
-    <div class="notice <%= notice.type === 'error' ? 'error' : 'success' %>">
-      <%= notice.message %>
-    </div>
-  <% } %>
   <form method="post" action="/admin/ip-bans" class="grid" style="grid-template-columns: repeat(auto-fit, minmax(220px,1fr)); gap:12px;">
     <div>
       <label for="ip">Adresse IP</label>

--- a/views/admin/pages.ejs
+++ b/views/admin/pages.ejs
@@ -14,7 +14,7 @@
         <p>… et <%= importResult.errors.length - 10 %> erreur(s) supplémentaire(s).</p>
       <% } %>
     <% } else { %>
-      <h2 style="margin-top:0;">Import terminé avec succès</h2>
+      <h2 style="margin-top:0; color:#111827;">Import terminé avec succès</h2>
     <% } %>
     <p>
       <strong><%= importResult.created || 0 %></strong> article(s) créé(s),

--- a/views/comment_edit.ejs
+++ b/views/comment_edit.ejs
@@ -1,16 +1,6 @@
 <% title = 'Modifier commentaire'; %>
 <section class="card">
   <h1>Modifier votre commentaire</h1>
-  <% if (typeof errors !== 'undefined' && errors.length) { %>
-    <div class="notice error">
-      <p>Impossible d'enregistrer les modifications :</p>
-      <ul>
-        <% errors.forEach(err => { %>
-          <li><%= err %></li>
-        <% }) %>
-      </ul>
-    </div>
-  <% } %>
   <form method="post" action="/wiki/<%= pageSlug %>/comments/<%= comment.snowflake_id %>/edit" class="comment-form">
     <div class="field">
       <label for="comment-author">Nom ou pseudo</label>

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -47,20 +47,6 @@
 <% const commentValues = (commentFeedback && commentFeedback.values) || {}; %>
 <section class="card comments" id="comments">
   <h2 style="margin-top:0">Commentaires</h2>
-  <% if (commentFeedback && commentFeedback.success) { %>
-    <div class="notice success"><%= commentFeedback.message || "Merci ! Votre commentaire a été enregistré et sera publié après validation." %></div>
-  <% } %>
-  <% if (commentFeedback && commentFeedback.errors && commentFeedback.errors.length) { %>
-    <div class="notice error">
-      <p style="margin-top:0;">Impossible d'enregistrer le commentaire :</p>
-      <ul>
-        <% commentFeedback.errors.forEach(err => { %>
-          <li><%= err %></li>
-        <% }) %>
-      </ul>
-    </div>
-  <% } %>
-
   <% if (comments && comments.length) { %>
     <ul class="comment-list">
       <% comments.forEach(c => { %>


### PR DESCRIPTION
## Summary
- push notifications for comment submissions, edits, and deletions while removing redundant inline notices in the UI
- add toast feedback across admin workflows (comments, IP bans, imports, uploads, settings, users, likes) and allow comment deletion from the moderation history
- tweak styles to improve the admin import banner contrast and display full IP addresses in tables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9967ad5688321ab964274f2a9768e