### PR TITLE
Upload editor images through media library

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -998,6 +998,29 @@ code {
   font-size: 1rem;
 }
 
+.html-editor {
+  position: relative;
+}
+
+.html-editor[data-uploading-image="true"] {
+  pointer-events: none;
+}
+
+.html-editor[data-uploading-image="true"]::after {
+  content: "Téléversement de l'image…";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(8, 10, 15, 0.7);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  backdrop-filter: blur(2px);
+}
+
 .html-editor .ql-editor p {
   margin-bottom: 0.75em;
 }

--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -35,6 +35,7 @@
       data-html-editor
       data-target="#contentField"
       data-toolbar="#editorToolbar"
+      data-upload-endpoint="/admin/uploads"
       aria-label="Éditeur de contenu"
     ></div>
   </div>


### PR DESCRIPTION
## Summary
- hook the Quill image tool to upload selected files to the admin uploads endpoint and insert the returned URL
- expose the upload endpoint via the editor markup and show visual feedback while an image is uploading
- add styles for the uploading state so the editor is blocked during the transfer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9a82bb9f083218755facd734d43ca