### PR TITLE
Use notification for successful page import

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -598,12 +598,16 @@ r.post(
         }
       }
 
-      req.session.importResult = summary;
-      const importSummaryMessage =
-        `Import terminé : ${summary.created} créé(s), ${summary.updated} mis à jour, ${summary.skipped} ignoré(s).` +
-        (summary.errors.length
-          ? ` ${summary.errors.length} erreur(s) à consulter.`
-          : "");
+      if (summary.errors.length) {
+        req.session.importResult = summary;
+      } else {
+        delete req.session.importResult;
+      }
+      const baseSummaryMessage =
+        `${summary.created} article(s) créé(s), ${summary.updated} article(s) mis à jour, ${summary.skipped} article(s) ignoré(s).`;
+      const importSummaryMessage = summary.errors.length
+        ? `Import terminé : ${baseSummaryMessage} ${summary.errors.length} erreur(s) à consulter.`
+        : `Import terminé avec succès : ${baseSummaryMessage}`;
       pushNotification(req, {
         type: summary.errors.length ? "info" : "success",
         message: importSummaryMessage,

--- a/views/admin/pages.ejs
+++ b/views/admin/pages.ejs
@@ -1,26 +1,29 @@
 <h1>Gestion des articles</h1>
 
-<% if (importResult) { %>
+<% const hasImportErrors = importResult && importResult.errors && importResult.errors.length; %>
+<% if (hasImportErrors) { %>
   <div class="card" style="padding:16px; margin-bottom:16px; background:#f4f6ff; border:1px solid #c7d2fe; border-radius:8px;">
-    <% if (importResult.errors && importResult.errors.length) { %>
-      <h2 style="margin-top:0;">Résultat de l'import</h2>
-      <p><strong><%= importResult.errors.length %></strong> erreur(s) détectée(s). Les entrées correspondantes ont été ignorées.</p>
-      <ul>
-        <% importResult.errors.slice(0, 10).forEach(err => { %>
-          <li><%= err %></li>
-        <% }) %>
-      </ul>
-      <% if (importResult.errors.length > 10) { %>
-        <p>… et <%= importResult.errors.length - 10 %> erreur(s) supplémentaire(s).</p>
-      <% } %>
-    <% } else { %>
-      <h2 style="margin-top:0; color:#111827;">Import terminé avec succès</h2>
+    <h2 style="margin-top:0;">Résultat de l'import</h2>
+    <p><strong><%= importResult.errors.length %></strong> erreur(s) détectée(s). Les entrées correspondantes ont été ignorées.</p>
+    <ul>
+      <% importResult.errors.slice(0, 10).forEach(err => { %>
+        <li><%= err %></li>
+      <% }) %>
+    </ul>
+    <% if (importResult.errors.length > 10) { %>
+      <p>… et <%= importResult.errors.length - 10 %> erreur(s) supplémentaire(s).</p>
     <% } %>
-    <p>
-      <strong><%= importResult.created || 0 %></strong> article(s) créé(s),
-      <strong><%= importResult.updated || 0 %></strong> article(s) mis à jour,
-      <strong><%= importResult.skipped || 0 %></strong> article(s) ignoré(s).
-    </p>
+    <% if (
+      typeof importResult.created !== "undefined" ||
+      typeof importResult.updated !== "undefined" ||
+      typeof importResult.skipped !== "undefined"
+    ) { %>
+      <p>
+        <strong><%= importResult.created || 0 %></strong> article(s) créé(s),
+        <strong><%= importResult.updated || 0 %></strong> article(s) mis à jour,
+        <strong><%= importResult.skipped || 0 %></strong> article(s) ignoré(s).
+      </p>
+    <% } %>
   </div>
 <% } %>
 


### PR DESCRIPTION
## Summary
- send success feedback for page imports via notifications instead of an inline card
- keep the detailed error panel only when an import reports issues
- adjust the success notification copy to mirror the previous inline message

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9aaa378e08321ad588a6f48da54e8