### PR TITLE
Separate active and lifted IP ban history

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -174,14 +174,24 @@ r.delete("/comments/:id", handleCommentDeletion);
 r.post("/comments/:id/delete", handleCommentDeletion);
 
 r.get("/ip-bans", async (req, res) => {
-  const bans = await all(
-    `SELECT snowflake_id, ip, scope, value, reason, created_at, lifted_at
-       FROM ip_bans
-      ORDER BY created_at DESC
-      LIMIT 200`,
-  );
+  const [activeBans, liftedBans] = await Promise.all([
+    all(
+      `SELECT snowflake_id, ip, scope, value, reason, created_at, lifted_at
+         FROM ip_bans
+        WHERE lifted_at IS NULL
+        ORDER BY created_at DESC`,
+    ),
+    all(
+      `SELECT snowflake_id, ip, scope, value, reason, created_at, lifted_at
+         FROM ip_bans
+        WHERE lifted_at IS NOT NULL
+        ORDER BY lifted_at DESC
+        LIMIT 200`,
+    ),
+  ]);
   res.render("admin/ip_bans", {
-    bans,
+    activeBans,
+    liftedBans,
   });
 });
 

--- a/views/admin/ip_bans.ejs
+++ b/views/admin/ip_bans.ejs
@@ -34,9 +34,49 @@
 </section>
 
 <section class="card">
-  <h2>Blocages actifs et historiques</h2>
-  <% if (!bans.length) { %>
-    <p>Aucun blocage enregistré.</p>
+  <h2>Blocages actifs</h2>
+  <% if (!activeBans.length) { %>
+    <p>Aucun blocage actif.</p>
+  <% } else { %>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>IP</th>
+            <th>Type</th>
+            <th>Valeur</th>
+            <th>Motif</th>
+            <th>Créé</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% activeBans.forEach(ban => { %>
+            <tr>
+              <td><%= ban.snowflake_id %></td>
+              <td><code><%= ban.ip %></code></td>
+              <td><%= ban.scope %></td>
+              <td><%= ban.value || '-' %></td>
+              <td><%= ban.reason || '-' %></td>
+              <td><%= new Date(ban.created_at).toLocaleString('fr-FR') %></td>
+              <td>
+                <form method="post" action="/admin/ip-bans/<%= ban.snowflake_id %>/lift" onsubmit="return confirm('Lever ce blocage ?');">
+                  <button class="btn secondary" data-icon="🗝️" type="submit">Lever</button>
+                </form>
+              </td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+  <% } %>
+</section>
+
+<section class="card">
+  <h2>Blocages levés</h2>
+  <% if (!liftedBans.length) { %>
+    <p>Aucun blocage levé enregistré.</p>
   <% } else { %>
     <div class="table-wrap">
       <table class="data-table">
@@ -49,11 +89,10 @@
             <th>Motif</th>
             <th>Créé</th>
             <th>Levée</th>
-            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
-          <% bans.forEach(ban => { %>
+          <% liftedBans.forEach(ban => { %>
             <tr>
               <td><%= ban.snowflake_id %></td>
               <td><code><%= ban.ip %></code></td>
@@ -61,16 +100,7 @@
               <td><%= ban.value || '-' %></td>
               <td><%= ban.reason || '-' %></td>
               <td><%= new Date(ban.created_at).toLocaleString('fr-FR') %></td>
-              <td><%= ban.lifted_at ? new Date(ban.lifted_at).toLocaleString('fr-FR') : 'Actif' %></td>
-              <td>
-                <% if (!ban.lifted_at) { %>
-                  <form method="post" action="/admin/ip-bans/<%= ban.snowflake_id %>/lift" onsubmit="return confirm('Lever ce blocage ?');">
-                    <button class="btn secondary" data-icon="🗝️" type="submit">Lever</button>
-                  </form>
-                <% } else { %>
-                  <span style="color:#94a3b8;">Terminé</span>
-                <% } %>
-              </td>
+              <td><%= new Date(ban.lifted_at).toLocaleString('fr-FR') %></td>
             </tr>
           <% }) %>
         </tbody>


### PR DESCRIPTION
## Summary
- split the IP ban admin listing into active and lifted sections
- adjust the query to fetch active bans separately from lifted bans

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b241d42483219ba92e4201821819