### PR TITLE
Stabilize code block editing UX

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1082,6 +1082,17 @@ code {
   appearance: none;
 }
 
+.html-editor-toolbar .ql-code-language option {
+  color: var(--text);
+  background: #111625;
+}
+
+.html-editor-toolbar .ql-code-language option:checked,
+.html-editor-toolbar .ql-code-language option[selected] {
+  color: #f8fafc;
+  background: #253362;
+}
+
 .html-editor-toolbar .ql-code-language:focus {
   outline: none;
   border-color: var(--accent);


### PR DESCRIPTION
## Summary
- debounce syntax highlighting so code block highlighting no longer steals the cursor while typing
- preserve selection/scroll position when re-highlighting and refresh immediately after language changes
- improve the code language dropdown styling for contrast and readability

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68d9c33a5fa88321891cf09439a58a8c