### PR TITLE
Fix admin code language picker styling

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1065,39 +1065,141 @@ code {
   margin-bottom: 0.75em;
 }
 
-.html-editor-toolbar .ql-code-language {
+
+.html-editor-toolbar .ql-picker.ql-code-language,
+.html-editor-toolbar select.ql-code-language {
+  --code-language-bg: rgba(13, 18, 32, 0.95);
+  --code-language-bg-focus: rgba(17, 25, 46, 0.98);
+  --code-language-text: var(--text);
+  --code-language-border: var(--border);
   min-width: 160px;
   margin-left: 6px;
-  padding: 0.35rem 0.6rem;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: rgba(13, 18, 32, 0.95);
-  color: var(--text);
   font-size: 0.9rem;
   font-family: inherit;
+  color: var(--code-language-text);
+}
+
+.html-editor-toolbar .ql-picker.ql-code-language {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  float: none;
+  border-radius: 10px;
+  border: 1px solid var(--code-language-border);
+  background-color: var(--code-language-bg);
   transition:
     border-color 160ms ease,
     box-shadow 160ms ease,
-    background 160ms ease;
-  appearance: none;
+    background-color 160ms ease,
+    color 160ms ease;
 }
 
-.html-editor-toolbar .ql-code-language option {
-  color: var(--text);
+.html-editor-toolbar .ql-picker.ql-code-language .ql-picker-label {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+  padding: 0.35rem 2.25rem 0.35rem 0.75rem;
+  color: inherit;
+}
+
+.html-editor-toolbar .ql-picker.ql-code-language .ql-picker-label::before {
+  color: inherit;
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.html-editor-toolbar .ql-picker.ql-code-language .ql-picker-label svg {
+  display: none;
+}
+
+.html-editor-toolbar .ql-picker.ql-code-language .ql-picker-label::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 0.85rem;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-right: 2px solid var(--muted);
+  border-bottom: 2px solid var(--muted);
+  transform: translateY(-50%) rotate(45deg);
+  transition: transform 160ms ease, border-color 160ms ease;
+}
+
+.html-editor-toolbar .ql-picker.ql-code-language.ql-expanded .ql-picker-label::after,
+.html-editor-toolbar .ql-picker.ql-code-language:focus-within .ql-picker-label::after {
+  transform: rotate(-135deg);
+  border-color: var(--accent);
+}
+
+.html-editor-toolbar .ql-picker.ql-code-language .ql-picker-options {
+  background-color: #111625;
+  border: 1px solid var(--code-language-border);
+  border-radius: 12px;
+  padding: 0.35rem 0.4rem;
+  margin-top: 6px;
+  box-shadow: 0 18px 36px rgba(8, 11, 24, 0.6);
+}
+
+.html-editor-toolbar .ql-picker.ql-code-language .ql-picker-item {
+  color: var(--code-language-text);
+  padding: 0.35rem 0.85rem;
+  border-radius: 8px;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.html-editor-toolbar .ql-picker.ql-code-language .ql-picker-item:hover,
+.html-editor-toolbar .ql-picker.ql-code-language .ql-picker-item.ql-selected {
+  background-color: #253362;
+  color: #f8fafc;
+}
+
+.html-editor-toolbar select.ql-code-language {
+  padding: 0.35rem 2.25rem 0.35rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid var(--code-language-border);
+  background-color: var(--code-language-bg);
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+    linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+  background-position:
+    calc(100% - 18px) 50%,
+    calc(100% - 13px) 50%;
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+  color: var(--code-language-text);
+  appearance: none;
+  color-scheme: dark;
+}
+
+.html-editor-toolbar select.ql-code-language option {
+  color: var(--code-language-text);
   background: #111625;
 }
 
-.html-editor-toolbar .ql-code-language option:checked,
-.html-editor-toolbar .ql-code-language option[selected] {
+.html-editor-toolbar select.ql-code-language option:disabled {
+  color: var(--muted);
+}
+
+.html-editor-toolbar select.ql-code-language:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 var(--code-language-text);
+}
+
+.html-editor-toolbar select.ql-code-language option:checked,
+.html-editor-toolbar select.ql-code-language option[selected] {
   color: #f8fafc;
   background: #253362;
 }
 
-.html-editor-toolbar .ql-code-language:focus {
+.html-editor-toolbar .ql-picker.ql-code-language.ql-expanded,
+.html-editor-toolbar .ql-picker.ql-code-language:focus-within,
+.html-editor-toolbar select.ql-code-language:focus {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 2px rgba(79, 109, 251, 0.25);
-  background: rgba(17, 25, 46, 0.98);
+  background-color: var(--code-language-bg-focus);
 }
 
 .html-editor .ql-editor pre.ql-syntax {


### PR DESCRIPTION
## Summary
- restyle the Quill language picker to match the dark theme and keep the selected language visible
- ensure the dropdown options and select fallback share the new styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9c571eae8832187ceac4d307929ff