### PR TITLE
Fix code block language selection and inline code contrast

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1162,7 +1162,8 @@ code {
   font-size: 1rem;
 }
 
-.html-editor .ql-editor code {
+.html-editor .ql-editor code,
+.html-editor .ql-editor span.ql-code {
   background: rgba(15, 18, 32, 0.92);
   border: 1px solid rgba(88, 101, 242, 0.35);
   color: #f8fafc;


### PR DESCRIPTION
## Summary
- ensure the Quill language dropdown targets the original select element and keeps the last selection when applying formats
- improve inline code styling inside the rich text editor so code text remains legible

## Testing
- npm run db:init
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d9d1a0b8848321984c53cf56b5b717