### PR TITLE
Affiche les statistiques des articles

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -389,6 +389,23 @@ body {
 .excerpt-body > :last-child {
   margin-bottom: 0;
 }
+.page-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 8px 0 12px;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+.page-stats span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.page-stats span strong {
+  color: var(--text);
+  font-weight: 600;
+}
 .excerpt pre {
   background: #0c0f18;
   border: 1px solid #242a3a;

--- a/utils/pageService.js
+++ b/utils/pageService.js
@@ -29,6 +29,7 @@ export async function fetchRecentPages({
            ${TAGS_CSV_SUBQUERY} AS tagsCsv,
            (SELECT COUNT(*) FROM likes WHERE page_id = p.id) AS likes,
            (SELECT COUNT(*) FROM likes WHERE page_id = p.id AND ip = ?) AS userLiked,
+           COALESCE((SELECT COUNT(*) FROM comments WHERE page_id = p.id AND status = 'approved'), 0) AS comment_count,
            ${VIEW_COUNT_SELECT} AS views
       FROM pages p
      WHERE p.created_at >= ?
@@ -56,6 +57,7 @@ export async function fetchPaginatedPages({
            ${TAGS_CSV_SUBQUERY} AS tagsCsv,
            (SELECT COUNT(*) FROM likes WHERE page_id = p.id) AS likes,
            (SELECT COUNT(*) FROM likes WHERE page_id = p.id AND ip = ?) AS userLiked,
+           COALESCE((SELECT COUNT(*) FROM comments WHERE page_id = p.id AND status = 'approved'), 0) AS comment_count,
            ${VIEW_COUNT_SELECT} AS views
       FROM pages p
      ORDER BY p.created_at DESC
@@ -71,6 +73,7 @@ export async function fetchPageWithStats(slugId, ip) {
     SELECT p.*,
            (SELECT COUNT(*) FROM likes WHERE page_id = p.id) AS likes,
            (SELECT COUNT(*) FROM likes WHERE page_id = p.id AND ip = ?) AS userLiked,
+           COALESCE((SELECT COUNT(*) FROM comments WHERE page_id = p.id AND status = 'approved'), 0) AS comment_count,
            ${VIEW_COUNT_SELECT} AS views
       FROM pages p
      WHERE slug_id = ?
@@ -115,6 +118,7 @@ export async function fetchPagesByTag({ tagName, ip, excerptLength = 1200 }) {
            ${TAGS_CSV_SUBQUERY} AS tagsCsv,
            (SELECT COUNT(*) FROM likes WHERE page_id = p.id) AS likes,
            (SELECT COUNT(*) FROM likes WHERE page_id = p.id AND ip = ?) AS userLiked,
+           COALESCE((SELECT COUNT(*) FROM comments WHERE page_id = p.id AND status = 'approved'), 0) AS comment_count,
            ${VIEW_COUNT_SELECT} AS views
       FROM pages p
       JOIN page_tags pt ON p.id = pt.page_id

--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -31,7 +31,7 @@
         <button class="ql-script" value="super" aria-label="Exposant"></button>
         <button class="ql-blockquote" aria-label="Bloc de citation"></button>
         <button class="ql-code-block" aria-label="Bloc de code"></button>
-        <button type="button" class="ql-divider" aria-label="Séparation">—</button>
+        <button type="button" class="ql-divider" aria-label="Séparation"></button>
       </span>
       <span class="ql-formats">
         <button class="ql-link" aria-label="Insérer un lien"></button>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -15,6 +15,11 @@
           <% tags.forEach(t => { %><a class="tag" href="/tags/<%= t %>"><%= t %></a><% }) %>
         </div>
       <% } %>
+      <div class="page-stats" aria-label="Statistiques de l’article">
+        <span title="Likes">💖 <strong><%= p.likes %></strong></span>
+        <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
+        <span title="Vues">👁️ <strong><%= p.views %></strong></span>
+      </div>
       <div class="actions">
         <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
         <form action="/wiki/<%= p.slug_id %>/like" method="post">
@@ -55,6 +60,11 @@
           <% tags.forEach(t => { %><a class="tag" href="/tags/<%= t %>"><%= t %></a><% }) %>
         </div>
       <% } %>
+      <div class="page-stats" aria-label="Statistiques de l’article">
+        <span title="Likes">💖 <strong><%= p.likes %></strong></span>
+        <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
+        <span title="Vues">👁️ <strong><%= p.views %></strong></span>
+      </div>
       <div class="actions">
         <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
         <form action="/wiki/<%= p.slug_id %>/like" method="post">

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -5,8 +5,9 @@
     <div class="meta">
       <span>Créé: <%= page.created_at %></span>
       <% if (page.updated_at) { %><span>• Modifié: <%= page.updated_at %></span><% } %>
-      <span>• Vues: <strong><%= page.views %></strong></span>
       <span>• Likes: <strong><%= page.likes %></strong></span>
+      <span>• Commentaires: <strong><%= comments.length %></strong></span>
+      <span>• Vues: <strong><%= page.views %></strong></span>
     </div>
   </div>
   <div class="actions">

--- a/views/tags.ejs
+++ b/views/tags.ejs
@@ -15,6 +15,11 @@
           <% tags.forEach(t => { %><a class="tag" href="/tags/<%= t %>"><%= t %></a><% }) %>
         </div>
       <% } %>
+      <div class="page-stats" aria-label="Statistiques de l’article">
+        <span title="Likes">💖 <strong><%= p.likes %></strong></span>
+        <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
+        <span title="Vues">👁️ <strong><%= p.views %></strong></span>
+      </div>
       <div class="actions">
         <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
         <form action="/wiki/<%= p.slug_id %>/like" method="post">


### PR DESCRIPTION
## Summary
- expose le nombre de commentaires dans les requêtes de listes et de pages
- affiche un bloc likes/commentaires/vues sur l’accueil et les pages de tag
- harmonise les métadonnées des articles et supprime le tiret affiché dans l’éditeur

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9d7aaa98c83219691cea6112e772f