### PR TITLE
Enable AJAX likes without page reload

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -16,18 +16,22 @@
         </div>
       <% } %>
       <div class="page-stats" aria-label="Statistiques de l’article">
-        <span title="Likes">💖 <strong><%= p.likes %></strong></span>
+        <span title="Likes">💖 <strong data-like-count-for="<%= p.slug_id %>"><%= p.likes %></strong></span>
         <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
         <span title="Vues">👁️ <strong><%= p.views %></strong></span>
       </div>
       <div class="actions">
         <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
-        <form action="/wiki/<%= p.slug_id %>/like" method="post">
-          <% if (p.userLiked) { %>
-            <button class="btn unlike" data-icon="💔">Retirer (<%= p.likes %>)</button>
-          <% } else { %>
-            <button class="btn like" data-icon="💖">Like (<%= p.likes %>)</button>
-          <% } %>
+        <form action="/wiki/<%= p.slug_id %>/like" method="post" data-like-form-for="<%= p.slug_id %>">
+          <button
+            class="btn <%= p.userLiked ? 'unlike' : 'like' %>"
+            data-icon="<%= p.userLiked ? '💔' : '💖' %>"
+            data-label-liked="Retirer"
+            data-label-unliked="Like"
+            type="submit"
+          >
+            <%= p.userLiked ? 'Retirer' : 'Like' %> (<%= p.likes %>)
+          </button>
         </form>
         <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')">Copier le lien</button>
       </div>
@@ -61,18 +65,22 @@
         </div>
       <% } %>
       <div class="page-stats" aria-label="Statistiques de l’article">
-        <span title="Likes">💖 <strong><%= p.likes %></strong></span>
+        <span title="Likes">💖 <strong data-like-count-for="<%= p.slug_id %>"><%= p.likes %></strong></span>
         <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
         <span title="Vues">👁️ <strong><%= p.views %></strong></span>
       </div>
       <div class="actions">
         <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
-        <form action="/wiki/<%= p.slug_id %>/like" method="post">
-          <% if (p.userLiked) { %>
-            <button class="btn unlike" data-icon="💔">Retirer (<%= p.likes %>)</button>
-          <% } else { %>
-            <button class="btn like" data-icon="💖">Like (<%= p.likes %>)</button>
-          <% } %>
+        <form action="/wiki/<%= p.slug_id %>/like" method="post" data-like-form-for="<%= p.slug_id %>">
+          <button
+            class="btn <%= p.userLiked ? 'unlike' : 'like' %>"
+            data-icon="<%= p.userLiked ? '💔' : '💖' %>"
+            data-label-liked="Retirer"
+            data-label-unliked="Like"
+            type="submit"
+          >
+            <%= p.userLiked ? 'Retirer' : 'Like' %> (<%= p.likes %>)
+          </button>
         </form>
         <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')">Copier le lien</button>
       </div>

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -5,18 +5,22 @@
     <div class="meta">
       <span>Créé: <%= page.created_at %></span>
       <% if (page.updated_at) { %><span>• Modifié: <%= page.updated_at %></span><% } %>
-      <span>• Likes: <strong><%= page.likes %></strong></span>
+      <span>• Likes: <strong data-like-count-for="<%= page.slug_id %>"><%= page.likes %></strong></span>
       <span>• Commentaires: <strong><%= comments.length %></strong></span>
       <span>• Vues: <strong><%= page.views %></strong></span>
     </div>
   </div>
   <div class="actions">
-    <form action="/wiki/<%= page.slug_id %>/like" method="post">
-      <% if (page.userLiked) { %>
-        <button class="btn unlike" data-icon="💔">Retirer le like (<%= page.likes %>)</button>
-      <% } else { %>
-        <button class="btn like" data-icon="💖">Like (<%= page.likes %>)</button>
-      <% } %>
+    <form action="/wiki/<%= page.slug_id %>/like" method="post" data-like-form-for="<%= page.slug_id %>">
+      <button
+        class="btn <%= page.userLiked ? 'unlike' : 'like' %>"
+        data-icon="<%= page.userLiked ? '💔' : '💖' %>"
+        data-label-liked="Retirer le like"
+        data-label-unliked="Like"
+        type="submit"
+      >
+        <%= page.userLiked ? 'Retirer le like' : 'Like' %> (<%= page.likes %>)
+      </button>
     </form>
     <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= page.slug_id %>')">Copier le lien</button>
     <% const currentUser = typeof user !== 'undefined' && user ? user : null; %>

--- a/views/tags.ejs
+++ b/views/tags.ejs
@@ -16,18 +16,22 @@
         </div>
       <% } %>
       <div class="page-stats" aria-label="Statistiques de l’article">
-        <span title="Likes">💖 <strong><%= p.likes %></strong></span>
+        <span title="Likes">💖 <strong data-like-count-for="<%= p.slug_id %>"><%= p.likes %></strong></span>
         <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
         <span title="Vues">👁️ <strong><%= p.views %></strong></span>
       </div>
       <div class="actions">
         <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
-        <form action="/wiki/<%= p.slug_id %>/like" method="post">
-          <% if (p.userLiked) { %>
-            <button class="btn unlike" data-icon="💔">Retirer (<%= p.likes %>)</button>
-          <% } else { %>
-            <button class="btn like" data-icon="💖">Like (<%= p.likes %>)</button>
-          <% } %>
+        <form action="/wiki/<%= p.slug_id %>/like" method="post" data-like-form-for="<%= p.slug_id %>">
+          <button
+            class="btn <%= p.userLiked ? 'unlike' : 'like' %>"
+            data-icon="<%= p.userLiked ? '💔' : '💖' %>"
+            data-label-liked="Retirer"
+            data-label-unliked="Like"
+            type="submit"
+          >
+            <%= p.userLiked ? 'Retirer' : 'Like' %> (<%= p.likes %>)
+          </button>
         </form>
         <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')">Copier le lien</button>
       </div>


### PR DESCRIPTION
## Summary
- return JSON responses for like toggles to support asynchronous updates
- intercept like form submissions on the client and refresh counts/buttons without reloading
- annotate views with data attributes so counts and labels stay in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9d90cb3488321a84eadbbcbd5fd6c