### PR TITLE
Expand admin export/import coverage

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -4,7 +4,7 @@ import multer from "multer";
 import path from "path";
 import { randomUUID } from "crypto";
 import { requireAdmin } from "../middleware/auth.js";
-import { all, get, run, randSlugId } from "../db.js";
+import { all, get, run, randSlugId, savePageFts } from "../db.js";
 import { slugify } from "../utils/linkify.js";
 import { sendAdminEvent } from "../utils/webhook.js";
 import { hashPassword } from "../utils/passwords.js";
@@ -23,6 +23,7 @@ import { getClientIp } from "../utils/ip.js";
 import {
   getSiteSettingsForForm,
   updateSiteSettingsFromForm,
+  invalidateSiteSettingsCache,
 } from "../utils/settingsService.js";
 import { pushNotification } from "../utils/notifications.js";
 
@@ -413,15 +414,21 @@ r.get("/stats", async (_req, res) => {
 });
 
 r.get("/pages/export", async (_req, res) => {
-  const rows = await all(`
-    SELECT p.slug_base, p.slug_id, p.title, p.content, p.created_at, p.updated_at,
+  const settingsRow = await get(
+    `SELECT id, wiki_name, logo_url, admin_webhook_url, feed_webhook_url, footer_text
+       FROM settings
+      WHERE id=1`,
+  );
+  const pageRows = await all(`
+    SELECT p.id, p.slug_base, p.slug_id, p.title, p.content, p.created_at, p.updated_at,
       (SELECT GROUP_CONCAT(t.name, ',') FROM tags t
         JOIN page_tags pt ON pt.tag_id = t.id
        WHERE pt.page_id = p.id) AS tagsCsv
     FROM pages p
     ORDER BY p.created_at ASC
   `);
-  const pages = rows.map((r) => ({
+  const pages = pageRows.map((r) => ({
+    id: r.id,
     slug_base: r.slug_base,
     slug_id: r.slug_id,
     title: r.title,
@@ -435,28 +442,49 @@ r.get("/pages/export", async (_req, res) => {
           .filter(Boolean)
       : [],
   }));
+  const users = await all(
+    `SELECT id, username, password, is_admin FROM users ORDER BY id ASC`,
+  );
   const likes = await all(`
     SELECT l.id, l.page_id, p.slug_id, l.ip, l.created_at
       FROM likes l
       JOIN pages p ON p.id = l.page_id
      ORDER BY l.created_at ASC`);
   const comments = await all(`
-    SELECT c.snowflake_id AS id, c.page_id, p.slug_id, c.author, c.body, c.status, c.created_at, c.updated_at, c.ip
+    SELECT c.id, c.snowflake_id AS snowflake_id, c.page_id, p.slug_id, c.author, c.body, c.status,
+           c.created_at, c.updated_at, c.ip, c.edit_token
       FROM comments c
       JOIN pages p ON p.id = c.page_id
      ORDER BY c.created_at ASC`);
   const viewEvents = await all(`
-    SELECT pv.page_id, p.slug_id, pv.ip, pv.viewed_at
+    SELECT pv.id, pv.page_id, p.slug_id, pv.ip, pv.viewed_at
       FROM page_views pv
       JOIN pages p ON p.id = pv.page_id
      ORDER BY pv.viewed_at ASC`);
   const aggregatedViews = await all(`
-    SELECT page_id, day, views FROM page_view_daily ORDER BY day ASC`);
+    SELECT v.page_id, p.slug_id, v.day, v.views
+      FROM page_view_daily v
+      JOIN pages p ON p.id = v.page_id
+     ORDER BY v.day ASC`);
+  const pageRevisions = await all(`
+    SELECT pr.page_id, p.slug_id, pr.revision, pr.title, pr.content, pr.author_id, u.username AS author_username,
+           pr.created_at
+      FROM page_revisions pr
+      JOIN pages p ON p.id = pr.page_id
+      LEFT JOIN users u ON u.id = pr.author_id
+     ORDER BY p.slug_id ASC, pr.revision ASC`);
+  const uploads = await all(
+    `SELECT id, original_name, display_name, extension, size, created_at FROM uploads ORDER BY created_at ASC`,
+  );
   const ipBans = await all(
-    "SELECT snowflake_id AS id, ip, scope, value, reason, created_at, lifted_at FROM ip_bans ORDER BY created_at ASC",
+    `SELECT id, snowflake_id, ip, scope, value, reason, created_at, lifted_at
+       FROM ip_bans
+      ORDER BY created_at ASC`,
   );
   const events = await all(
-    "SELECT id, channel, type, payload, ip, username, created_at FROM event_logs ORDER BY created_at ASC",
+    `SELECT id, channel, type, payload, ip, username, created_at
+       FROM event_logs
+      ORDER BY created_at ASC`,
   );
   res.setHeader("Content-Type", "application/json; charset=utf-8");
   const date = new Date().toISOString().split("T")[0];
@@ -465,15 +493,33 @@ r.get("/pages/export", async (_req, res) => {
     `attachment; filename="wiki-pages-${date}.json"`,
   );
   const payload = {
+    schema_version: 2,
+    full_export: true,
     exported_at: new Date().toISOString(),
     count: pages.length,
+    counts: {
+      pages: pages.length,
+      users: users.length,
+      likes: likes.length,
+      comments: comments.length,
+      view_events: viewEvents.length,
+      view_daily: aggregatedViews.length,
+      revisions: pageRevisions.length,
+      uploads: uploads.length,
+      ip_bans: ipBans.length,
+      events: events.length,
+    },
+    settings: settingsRow || null,
+    users,
     pages,
+    page_revisions: pageRevisions,
     likes,
     comments,
     views: {
       events: viewEvents,
       daily: aggregatedViews,
     },
+    uploads,
     ip_bans: ipBans,
     events,
   };
@@ -521,94 +567,625 @@ r.post(
         return res.redirect("/admin/pages");
       }
 
-      const tagCache = new Map();
-      const summary = { created: 0, updated: 0, skipped: 0, errors: [] };
+      const likesInput = Array.isArray(parsed?.likes) ? parsed.likes : [];
+      const commentsInput = Array.isArray(parsed?.comments) ? parsed.comments : [];
+      const viewEventsInput = Array.isArray(parsed?.views?.events)
+        ? parsed.views.events
+        : [];
+      const viewDailyInput = Array.isArray(parsed?.views?.daily)
+        ? parsed.views.daily
+        : [];
+      const ipBansInput = Array.isArray(parsed?.ip_bans) ? parsed.ip_bans : [];
+      const eventsInput = Array.isArray(parsed?.events) ? parsed.events : [];
+      const usersInput = Array.isArray(parsed?.users) ? parsed.users : [];
+      const revisionsInput = Array.isArray(parsed?.page_revisions)
+        ? parsed.page_revisions
+        : [];
+      const uploadsInput = Array.isArray(parsed?.uploads) ? parsed.uploads : [];
+      const settingsInput =
+        parsed && typeof parsed === "object" && parsed.settings &&
+        typeof parsed.settings === "object"
+          ? parsed.settings
+          : null;
 
-      for (let idx = 0; idx < pages.length; idx++) {
-        const item = pages[idx] || {};
-        const title = typeof item.title === "string" ? item.title.trim() : "";
-        const content = typeof item.content === "string" ? item.content : "";
-        if (!title || !content) {
-          summary.errors.push(`Entrée #${idx + 1}: titre ou contenu manquant.`);
-          summary.skipped++;
+      const summary = {
+        created: 0,
+        updated: 0,
+        skipped: 0,
+        errors: [],
+        stats: {
+          users: 0,
+          likes: 0,
+          comments: 0,
+          viewEvents: 0,
+          viewDaily: 0,
+          ipBans: 0,
+          events: 0,
+          revisions: 0,
+          uploads: 0,
+        },
+        settingsUpdated: false,
+      };
+
+      const tagCache = new Map();
+      const slugToId = new Map();
+
+      await run("BEGIN TRANSACTION");
+      try {
+        if (settingsInput) {
+          const currentSettings = await get(
+            `SELECT wiki_name, logo_url, admin_webhook_url, feed_webhook_url, footer_text
+               FROM settings
+              WHERE id=1`,
+          );
+          const wikiName =
+            typeof settingsInput.wiki_name === "string"
+              ? settingsInput.wiki_name.trim()
+              : typeof settingsInput.wikiName === "string"
+                ? settingsInput.wikiName.trim()
+                : currentSettings?.wiki_name || "Wiki";
+          const logoUrl =
+            typeof settingsInput.logo_url === "string"
+              ? settingsInput.logo_url.trim()
+              : typeof settingsInput.logoUrl === "string"
+                ? settingsInput.logoUrl.trim()
+                : currentSettings?.logo_url || "";
+          const adminWebhook =
+            typeof settingsInput.admin_webhook_url === "string"
+              ? settingsInput.admin_webhook_url.trim()
+              : typeof settingsInput.adminWebhook === "string"
+                ? settingsInput.adminWebhook.trim()
+                : currentSettings?.admin_webhook_url || "";
+          const feedWebhook =
+            typeof settingsInput.feed_webhook_url === "string"
+              ? settingsInput.feed_webhook_url.trim()
+              : typeof settingsInput.feedWebhook === "string"
+                ? settingsInput.feedWebhook.trim()
+                : currentSettings?.feed_webhook_url || "";
+          const footerText =
+            typeof settingsInput.footer_text === "string"
+              ? settingsInput.footer_text.trim()
+              : typeof settingsInput.footerText === "string"
+                ? settingsInput.footerText.trim()
+                : currentSettings?.footer_text || "";
+          await run(
+            `UPDATE settings
+                SET wiki_name=?, logo_url=?, admin_webhook_url=?, feed_webhook_url=?, footer_text=?
+              WHERE id=1`,
+            [wikiName, logoUrl, adminWebhook, feedWebhook, footerText],
+          );
+          summary.settingsUpdated = true;
+        }
+
+        for (let idx = 0; idx < usersInput.length; idx++) {
+          const user = usersInput[idx] || {};
+          const username =
+            typeof user.username === "string" ? user.username.trim() : "";
+          const password =
+            typeof user.password === "string" ? user.password : "";
+          const isAdminRaw = user.is_admin ?? user.isAdmin ?? 0;
+        const isAdmin =
+          typeof isAdminRaw === "boolean"
+            ? isAdminRaw
+            : Number(isAdminRaw) === 1;
+        if (!username || !password) {
+          summary.errors.push(
+            `Utilisateur #${idx + 1}: identifiant ou mot de passe manquant.`,
+          );
           continue;
         }
-
-        let slugId =
-          typeof item.slug_id === "string" ? item.slug_id.trim() : "";
-        let slugBase =
-          typeof item.slug_base === "string" ? item.slug_base.trim() : "";
-        if (!slugBase) {
-          slugBase = slugify(title);
-        }
-        if (!slugId) {
-          slugId = randSlugId(slugBase);
-        }
-
-        const tagsRaw = Array.isArray(item.tags)
-          ? item.tags
-          : typeof item.tags === "string"
-            ? item.tags.split(",")
-            : [];
-        const tags = tagsRaw
-          .map((t) => (typeof t === "string" ? t.trim().toLowerCase() : ""))
-          .filter(Boolean);
-
-        const createdAt =
-          sanitizeDate(item.created_at) || new Date().toISOString();
-        const updatedAt = sanitizeDate(item.updated_at);
-
-        const existing = await get(
-          "SELECT id, created_at FROM pages WHERE slug_id=?",
-          [slugId],
-        );
-        let pageId;
-        if (existing) {
-          const finalCreatedAt =
-            sanitizeDate(item.created_at) || existing.created_at;
-          const finalUpdatedAt = updatedAt || new Date().toISOString();
+        const insertParams = [username, password, isAdmin ? 1 : 0];
+        const userId = parseInteger(user.id);
+        if (userId !== null) {
           await run(
-            "UPDATE pages SET slug_base=?, title=?, content=?, created_at=?, updated_at=? WHERE id=?",
-            [
-              slugBase,
-              title,
-              content,
-              finalCreatedAt,
-              finalUpdatedAt,
-              existing.id,
-            ],
+            `INSERT INTO users(id, username, password, is_admin) VALUES(?,?,?,?)
+             ON CONFLICT(username) DO UPDATE SET password=excluded.password, is_admin=excluded.is_admin`,
+            [userId, ...insertParams],
           );
-          pageId = existing.id;
-          summary.updated++;
         } else {
-          const result = await run(
-            "INSERT INTO pages(slug_base, slug_id, title, content, created_at, updated_at) VALUES(?,?,?,?,?,?)",
-            [slugBase, slugId, title, content, createdAt, updatedAt],
-          );
-          pageId = result.lastID;
-          summary.created++;
-        }
-
-        await run("DELETE FROM page_tags WHERE page_id=?", [pageId]);
-        for (const tagName of tags) {
-          let tagId = tagCache.get(tagName);
-          if (!tagId) {
-            await run("INSERT OR IGNORE INTO tags(name) VALUES(?)", [tagName]);
-            const row = await get("SELECT id FROM tags WHERE name=?", [
-              tagName,
-            ]);
-            tagId = row?.id;
-            if (tagId) {
-              tagCache.set(tagName, tagId);
-            }
-          }
-          if (tagId) {
-            await run(
-              "INSERT OR IGNORE INTO page_tags(page_id, tag_id) VALUES(?,?)",
-              [pageId, tagId],
+          await run(
+            `INSERT INTO users(username, password, is_admin) VALUES(?,?,?)
+             ON CONFLICT(username) DO UPDATE SET password=excluded.password, is_admin=excluded.is_admin`,
+              insertParams,
             );
           }
+          summary.stats.users++;
         }
+
+        const userRows = await all(`SELECT id, username FROM users`);
+        const usernameToId = new Map();
+        const userIdSet = new Set();
+        for (const row of userRows) {
+          usernameToId.set(row.username, row.id);
+          userIdSet.add(row.id);
+        }
+
+        for (let idx = 0; idx < pages.length; idx++) {
+          const item = pages[idx] || {};
+          const title = typeof item.title === "string" ? item.title.trim() : "";
+          const content = typeof item.content === "string" ? item.content : "";
+          if (!title || !content) {
+            summary.errors.push(
+              `Entrée #${idx + 1}: titre ou contenu manquant.`,
+            );
+            summary.skipped++;
+            continue;
+          }
+
+          let slugId =
+            typeof item.slug_id === "string" ? item.slug_id.trim() : "";
+          let slugBase =
+            typeof item.slug_base === "string" ? item.slug_base.trim() : "";
+          if (!slugBase) {
+            slugBase = slugify(title);
+          }
+          if (!slugId) {
+            slugId = randSlugId(slugBase);
+          }
+
+          const tagsRaw = Array.isArray(item.tags)
+            ? item.tags
+            : typeof item.tags === "string"
+              ? item.tags.split(",")
+              : [];
+          const tags = tagsRaw
+            .map((t) => (typeof t === "string" ? t.trim().toLowerCase() : ""))
+            .filter(Boolean);
+
+          const createdAt =
+            sanitizeDate(item.created_at) || new Date().toISOString();
+          const updatedAt = sanitizeDate(item.updated_at);
+
+          const existing = await get(
+            "SELECT id, created_at FROM pages WHERE slug_id=?",
+            [slugId],
+          );
+          let pageId;
+          if (existing) {
+            const finalCreatedAt =
+              sanitizeDate(item.created_at) || existing.created_at;
+            const finalUpdatedAt = updatedAt || new Date().toISOString();
+            await run(
+              "UPDATE pages SET slug_base=?, title=?, content=?, created_at=?, updated_at=? WHERE id=?",
+              [
+                slugBase,
+                title,
+                content,
+                finalCreatedAt,
+                finalUpdatedAt,
+                existing.id,
+              ],
+            );
+            pageId = existing.id;
+            summary.updated++;
+          } else {
+            const explicitId = parseInteger(item.id);
+            if (explicitId !== null) {
+            await run(
+              "INSERT INTO pages(id, slug_base, slug_id, title, content, created_at, updated_at) VALUES(?,?,?,?,?,?,?)",
+              [explicitId, slugBase, slugId, title, content, createdAt, updatedAt],
+            );
+            pageId = explicitId;
+            summary.created++;
+            } else {
+              const result = await run(
+                "INSERT INTO pages(slug_base, slug_id, title, content, created_at, updated_at) VALUES(?,?,?,?,?,?)",
+                [slugBase, slugId, title, content, createdAt, updatedAt],
+              );
+              pageId = result.lastID;
+              summary.created++;
+            }
+          }
+
+          slugToId.set(slugId, pageId);
+
+          await run("DELETE FROM page_tags WHERE page_id=?", [pageId]);
+          for (const tagName of tags) {
+            let tagId = tagCache.get(tagName);
+            if (!tagId) {
+              await run("INSERT OR IGNORE INTO tags(name) VALUES(?)", [tagName]);
+              const row = await get("SELECT id FROM tags WHERE name=?", [
+                tagName,
+              ]);
+              tagId = row?.id;
+              if (tagId) {
+                tagCache.set(tagName, tagId);
+              }
+            }
+            if (tagId) {
+              await run(
+                "INSERT OR IGNORE INTO page_tags(page_id, tag_id) VALUES(?,?)",
+                [pageId, tagId],
+              );
+            }
+          }
+
+          await savePageFts({
+            id: pageId,
+            title,
+            content,
+            slug_id: slugId,
+            tags: tags.join(","),
+          });
+        }
+
+        const slugRows = await all("SELECT id, slug_id FROM pages");
+        for (const row of slugRows) {
+          slugToId.set(row.slug_id, row.id);
+        }
+
+        for (let idx = 0; idx < revisionsInput.length; idx++) {
+          const revision = revisionsInput[idx] || {};
+          const slugId =
+            typeof revision.slug_id === "string" ? revision.slug_id.trim() : "";
+          const pageId = slugToId.get(slugId);
+          if (!pageId) {
+            summary.errors.push(
+              `Révision #${idx + 1}: page inconnue (${slugId || "sans slug"}).`,
+            );
+            continue;
+          }
+          const revisionNumber = parseInteger(revision.revision);
+          if (revisionNumber === null || revisionNumber < 1) {
+            summary.errors.push(
+              `Révision #${idx + 1}: numéro de révision invalide.`,
+            );
+            continue;
+          }
+          const title =
+            typeof revision.title === "string" ? revision.title : "";
+          const content =
+            typeof revision.content === "string" ? revision.content : "";
+          const createdAt = sanitizeDate(revision.created_at);
+          const authorUsername =
+            typeof revision.author_username === "string"
+              ? revision.author_username.trim()
+              : "";
+          let authorId = parseInteger(revision.author_id);
+          if (authorId && !userIdSet.has(authorId)) {
+            authorId = null;
+          }
+          if (!authorId && authorUsername) {
+            authorId = usernameToId.get(authorUsername) || null;
+          }
+          await run(
+            `INSERT INTO page_revisions(page_id, revision, title, content, author_id, created_at)
+             VALUES(?,?,?,?,?,?)
+             ON CONFLICT(page_id, revision) DO UPDATE SET
+               title=excluded.title,
+               content=excluded.content,
+               author_id=excluded.author_id,
+               created_at=excluded.created_at`,
+            [pageId, revisionNumber, title, content, authorId, createdAt],
+          );
+          summary.stats.revisions++;
+        }
+
+        for (let idx = 0; idx < likesInput.length; idx++) {
+          const like = likesInput[idx] || {};
+          const slugId =
+            typeof like.slug_id === "string" ? like.slug_id.trim() : "";
+          const pageId = slugToId.get(slugId);
+          if (!pageId) {
+            summary.errors.push(
+              `Like #${idx + 1}: page inconnue (${slugId || "sans slug"}).`,
+            );
+            continue;
+          }
+          const ipValue =
+            typeof like.ip === "string" && like.ip.trim()
+              ? like.ip.trim()
+              : null;
+          if (!ipValue) {
+            summary.errors.push(
+              `Like #${idx + 1}: adresse IP manquante pour ${slugId}.`,
+            );
+            continue;
+          }
+          const createdAt =
+            sanitizeDate(like.created_at) || new Date().toISOString();
+          const likeId = parseInteger(like.id);
+          if (likeId !== null) {
+            await run(
+              `INSERT INTO likes(id, page_id, ip, created_at) VALUES(?,?,?,?)
+               ON CONFLICT(id) DO UPDATE SET page_id=excluded.page_id, ip=excluded.ip, created_at=excluded.created_at`,
+              [likeId, pageId, ipValue, createdAt],
+            );
+          } else {
+            await run(
+              `INSERT INTO likes(page_id, ip, created_at) VALUES(?,?,?)
+               ON CONFLICT(page_id, ip) DO UPDATE SET created_at=excluded.created_at`,
+              [pageId, ipValue, createdAt],
+            );
+          }
+          summary.stats.likes++;
+        }
+
+        for (let idx = 0; idx < commentsInput.length; idx++) {
+          const comment = commentsInput[idx] || {};
+          const slugId =
+            typeof comment.slug_id === "string" ? comment.slug_id.trim() : "";
+          const pageId = slugToId.get(slugId);
+          if (!pageId) {
+            summary.errors.push(
+              `Commentaire #${idx + 1}: page inconnue (${slugId || "sans slug"}).`,
+            );
+            continue;
+          }
+          const snowflakeId =
+            typeof comment.snowflake_id === "string"
+              ? comment.snowflake_id
+              : typeof comment.id === "string"
+                ? comment.id
+                : null;
+          if (!snowflakeId) {
+            summary.errors.push(
+              `Commentaire #${idx + 1}: identifiant absent pour ${slugId}.`,
+            );
+            continue;
+          }
+          const author =
+            typeof comment.author === "string" ? comment.author : null;
+          const body =
+            typeof comment.body === "string" ? comment.body : "";
+          if (!body) {
+            summary.errors.push(
+              `Commentaire #${idx + 1}: contenu manquant pour ${slugId}.`,
+            );
+            continue;
+          }
+          const status =
+            typeof comment.status === "string" && comment.status
+              ? comment.status
+              : "pending";
+          const createdAt =
+            sanitizeDate(comment.created_at) || new Date().toISOString();
+          const updatedAt = sanitizeDate(comment.updated_at);
+          const ipValue =
+            typeof comment.ip === "string" && comment.ip.trim()
+              ? comment.ip.trim()
+              : null;
+          const editToken =
+            typeof comment.edit_token === "string"
+              ? comment.edit_token
+              : null;
+          const commentId = parseInteger(comment.id);
+          await run(
+            `INSERT INTO comments(id, snowflake_id, page_id, author, body, status, created_at, updated_at, ip, edit_token)
+             VALUES(?,?,?,?,?,?,?,?,?,?)
+             ON CONFLICT(snowflake_id) DO UPDATE SET
+               page_id=excluded.page_id,
+               author=excluded.author,
+               body=excluded.body,
+               status=excluded.status,
+               created_at=excluded.created_at,
+               updated_at=excluded.updated_at,
+               ip=excluded.ip,
+               edit_token=excluded.edit_token`,
+            [
+              commentId,
+              snowflakeId,
+              pageId,
+              author,
+              body,
+              status,
+              createdAt,
+              updatedAt,
+              ipValue,
+              editToken,
+            ],
+          );
+          summary.stats.comments++;
+        }
+
+        for (let idx = 0; idx < viewEventsInput.length; idx++) {
+          const view = viewEventsInput[idx] || {};
+          const slugId =
+            typeof view.slug_id === "string" ? view.slug_id.trim() : "";
+          const pageId = slugToId.get(slugId);
+          if (!pageId) {
+            summary.errors.push(
+              `Vue #${idx + 1}: page inconnue (${slugId || "sans slug"}).`,
+            );
+            continue;
+          }
+          const viewedAt =
+            sanitizeDate(view.viewed_at) || new Date().toISOString();
+          const ipValue =
+            typeof view.ip === "string" && view.ip.trim()
+              ? view.ip.trim()
+              : null;
+          const viewId = parseInteger(view.id);
+          if (viewId !== null) {
+            await run(
+              `INSERT INTO page_views(id, page_id, ip, viewed_at) VALUES(?,?,?,?)
+               ON CONFLICT(id) DO UPDATE SET page_id=excluded.page_id, ip=excluded.ip, viewed_at=excluded.viewed_at`,
+              [viewId, pageId, ipValue, viewedAt],
+            );
+          } else {
+            await run(
+              `INSERT INTO page_views(page_id, ip, viewed_at) VALUES(?,?,?)`,
+              [pageId, ipValue, viewedAt],
+            );
+          }
+          summary.stats.viewEvents++;
+        }
+
+        for (let idx = 0; idx < viewDailyInput.length; idx++) {
+          const view = viewDailyInput[idx] || {};
+          const slugId =
+            typeof view.slug_id === "string" ? view.slug_id.trim() : "";
+          const pageId = slugToId.get(slugId);
+          if (!pageId) {
+            summary.errors.push(
+              `Statistiques quotidiennes #${idx + 1}: page inconnue (${slugId || "sans slug"}).`,
+            );
+            continue;
+          }
+          const day = typeof view.day === "string" ? view.day : null;
+          if (!day) {
+            summary.errors.push(
+              `Statistiques quotidiennes #${idx + 1}: jour manquant.`,
+            );
+            continue;
+          }
+          const viewsValue = parseInteger(view.views);
+          const finalViews = viewsValue ?? 0;
+          await run(
+            `INSERT INTO page_view_daily(page_id, day, views) VALUES(?,?,?)
+             ON CONFLICT(page_id, day) DO UPDATE SET views=excluded.views`,
+            [pageId, day, finalViews],
+          );
+          summary.stats.viewDaily++;
+        }
+
+        for (let idx = 0; idx < uploadsInput.length; idx++) {
+          const upload = uploadsInput[idx] || {};
+          const id = typeof upload.id === "string" ? upload.id : null;
+          if (!id) {
+            summary.errors.push(
+              `Upload #${idx + 1}: identifiant manquant.`,
+            );
+            continue;
+          }
+          const originalName =
+            typeof upload.original_name === "string"
+              ? upload.original_name
+              : upload.originalName;
+          const extension =
+            typeof upload.extension === "string"
+              ? upload.extension
+              : null;
+          if (!originalName || !extension) {
+            summary.errors.push(
+              `Upload #${idx + 1}: nom d'origine ou extension manquants.`,
+            );
+            continue;
+          }
+          const displayName =
+            typeof upload.display_name === "string"
+              ? upload.display_name
+              : typeof upload.displayName === "string"
+                ? upload.displayName
+                : null;
+          const sizeValue = parseInteger(upload.size);
+          const createdAt = sanitizeDate(upload.created_at);
+          await run(
+            `INSERT INTO uploads(id, original_name, display_name, extension, size, created_at)
+             VALUES(?,?,?,?,?,?)
+             ON CONFLICT(id) DO UPDATE SET
+               original_name=excluded.original_name,
+               display_name=excluded.display_name,
+               extension=excluded.extension,
+               size=excluded.size,
+               created_at=excluded.created_at`,
+            [id, originalName, displayName, extension, sizeValue ?? null, createdAt],
+          );
+          summary.stats.uploads++;
+        }
+
+        for (let idx = 0; idx < ipBansInput.length; idx++) {
+          const ban = ipBansInput[idx] || {};
+          const snowflakeId =
+            typeof ban.snowflake_id === "string"
+              ? ban.snowflake_id
+              : typeof ban.id === "string"
+                ? ban.id
+                : null;
+          if (!snowflakeId) {
+            summary.errors.push(
+              `Blocage #${idx + 1}: identifiant manquant.`,
+            );
+            continue;
+          }
+          const ipValue = typeof ban.ip === "string" ? ban.ip.trim() : "";
+          const scope = typeof ban.scope === "string" ? ban.scope : null;
+          if (!ipValue || !scope) {
+            summary.errors.push(
+              `Blocage #${idx + 1}: IP ou portée manquante.`,
+            );
+            continue;
+          }
+          const createdAt = sanitizeDate(ban.created_at);
+          const liftedAt = sanitizeDate(ban.lifted_at);
+          const banId = parseInteger(ban.id);
+          await run(
+            `INSERT INTO ip_bans(id, snowflake_id, ip, scope, value, reason, created_at, lifted_at)
+             VALUES(?,?,?,?,?,?,?,?)
+             ON CONFLICT(snowflake_id) DO UPDATE SET
+               ip=excluded.ip,
+               scope=excluded.scope,
+               value=excluded.value,
+               reason=excluded.reason,
+               created_at=excluded.created_at,
+               lifted_at=excluded.lifted_at`,
+            [
+              banId,
+              snowflakeId,
+              ipValue,
+              scope,
+              typeof ban.value === "string" ? ban.value : null,
+              typeof ban.reason === "string" ? ban.reason : null,
+              createdAt,
+              liftedAt,
+            ],
+          );
+          summary.stats.ipBans++;
+        }
+
+        for (let idx = 0; idx < eventsInput.length; idx++) {
+          const event = eventsInput[idx] || {};
+          const eventId = parseInteger(event.id);
+          if (eventId === null) {
+            summary.errors.push(
+              `Événement #${idx + 1}: identifiant numérique requis.`,
+            );
+            continue;
+          }
+          const channel =
+            typeof event.channel === "string" ? event.channel : null;
+          const type = typeof event.type === "string" ? event.type : null;
+          if (!channel || !type) {
+            summary.errors.push(
+              `Événement #${idx + 1}: canal ou type manquant.`,
+            );
+            continue;
+          }
+          await run(
+            `INSERT INTO event_logs(id, channel, type, payload, ip, username, created_at)
+             VALUES(?,?,?,?,?,?,?)
+             ON CONFLICT(id) DO UPDATE SET
+               channel=excluded.channel,
+               type=excluded.type,
+               payload=excluded.payload,
+               ip=excluded.ip,
+               username=excluded.username,
+               created_at=excluded.created_at`,
+            [
+              eventId,
+              channel,
+              type,
+              typeof event.payload === "string"
+                ? event.payload
+                : event.payload
+                  ? JSON.stringify(event.payload)
+                  : null,
+              typeof event.ip === "string" ? event.ip : null,
+              typeof event.username === "string" ? event.username : null,
+              sanitizeDate(event.created_at) || new Date().toISOString(),
+            ],
+          );
+          summary.stats.events++;
+        }
+
+        await run("COMMIT");
+      } catch (transactionError) {
+        await run("ROLLBACK");
+        throw transactionError;
+      }
+
+      if (summary.settingsUpdated) {
+        invalidateSiteSettingsCache();
       }
 
       if (summary.errors.length) {
@@ -618,9 +1195,47 @@ r.post(
       }
       const baseSummaryMessage =
         `${summary.created} article(s) créé(s), ${summary.updated} article(s) mis à jour, ${summary.skipped} article(s) ignoré(s).`;
+      const extraMetrics = [];
+      if (summary.stats.users) {
+        extraMetrics.push(`${summary.stats.users} utilisateur(s)`);
+      }
+      if (summary.stats.likes) {
+        extraMetrics.push(`${summary.stats.likes} like(s)`);
+      }
+      if (summary.stats.comments) {
+        extraMetrics.push(`${summary.stats.comments} commentaire(s)`);
+      }
+      if (summary.stats.viewEvents || summary.stats.viewDaily) {
+        const viewsDetail = [];
+        if (summary.stats.viewEvents) {
+          viewsDetail.push(`${summary.stats.viewEvents} vue(s)`);
+        }
+        if (summary.stats.viewDaily) {
+          viewsDetail.push(`${summary.stats.viewDaily} statistique(s) quotidienne(s)`);
+        }
+        if (viewsDetail.length) {
+          extraMetrics.push(`statistiques (${viewsDetail.join(", ")})`);
+        }
+      }
+      if (summary.stats.revisions) {
+        extraMetrics.push(`${summary.stats.revisions} révision(s)`);
+      }
+      if (summary.stats.uploads) {
+        extraMetrics.push(`${summary.stats.uploads} fichier(s)`);
+      }
+      if (summary.stats.ipBans) {
+        extraMetrics.push(`${summary.stats.ipBans} blocage(s) IP`);
+      }
+      if (summary.stats.events) {
+        extraMetrics.push(`${summary.stats.events} événement(s) journalisé(s)`);
+      }
+      const extraSummary =
+        extraMetrics.length > 0
+          ? ` Données synchronisées : ${extraMetrics.join(", ")}.`
+          : "";
       const importSummaryMessage = summary.errors.length
-        ? `Import terminé : ${baseSummaryMessage} ${summary.errors.length} erreur(s) à consulter.`
-        : `Import terminé avec succès : ${baseSummaryMessage}`;
+        ? `Import terminé : ${baseSummaryMessage}${extraSummary} ${summary.errors.length} erreur(s) à consulter.`
+        : `Import terminé avec succès : ${baseSummaryMessage}${extraSummary}`;
       pushNotification(req, {
         type: summary.errors.length ? "info" : "success",
         message: importSummaryMessage,
@@ -637,6 +1252,8 @@ r.post(
             updated: summary.updated,
             skipped: summary.skipped,
             errors: summary.errors.slice(0, 5),
+            stats: summary.stats,
+            settingsUpdated: summary.settingsUpdated,
           },
         },
         { includeScreenshot: false },
@@ -653,6 +1270,17 @@ function sanitizeDate(value) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return null;
   return date.toISOString();
+}
+
+function parseInteger(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+  return parsed;
 }
 
 r.post("/uploads", upload.single("image"), async (req, res, next) => {


### PR DESCRIPTION
## Summary
- extend the admin export payload to include every persisted entity (settings, users, uploads, revisions, events, stats, etc.)
- revamp the admin import routine to restore the complete dataset with validation, transactions, and FTS updates
- enhance import reporting and admin event details to surface counts for the additional data types

## Testing
- node -e "import('./routes/admin.js')"

------
https://chatgpt.com/codex/tasks/task_e_68d9dca11f048321a44aee912f88ff02