### PR TITLE
Add snowflake identifiers across entities

### DIFF
--- a/scripts/aggregateViews.js
+++ b/scripts/aggregateViews.js
@@ -1,4 +1,5 @@
 import { initDb, all, run } from "../db.js";
+import { generateSnowflake } from "../utils/snowflake.js";
 
 await initDb();
 
@@ -31,10 +32,10 @@ let committed = false;
 try {
   for (const row of aggregates) {
     await run(
-      `INSERT INTO page_view_daily(page_id, day, views)
-       VALUES(?, ?, ?)
+      `INSERT INTO page_view_daily(snowflake_id, page_id, day, views)
+       VALUES(?, ?, ?, ?)
        ON CONFLICT(page_id, day) DO UPDATE SET views = views + excluded.views`,
-      [row.page_id, row.day, row.views],
+      [generateSnowflake(), row.page_id, row.day, row.views],
     );
   }
   await run("DELETE FROM page_views WHERE viewed_at < ?", [cutoffIso]);

--- a/utils/pageService.js
+++ b/utils/pageService.js
@@ -22,6 +22,7 @@ export async function fetchRecentPages({
   return all(
     `
     SELECT p.id,
+           p.snowflake_id,
            p.title,
            p.slug_id,
            substr(p.content, 1, ${excerpt}) AS excerpt,
@@ -50,6 +51,7 @@ export async function fetchPaginatedPages({
   return all(
     `
     SELECT p.id,
+           p.snowflake_id,
            p.title,
            p.slug_id,
            substr(p.content, 1, ${excerpt}) AS excerpt,
@@ -111,6 +113,7 @@ export async function fetchPagesByTag({ tagName, ip, excerptLength = 1200 }) {
   return all(
     `
     SELECT p.id,
+           p.snowflake_id,
            p.title,
            p.slug_id,
            substr(p.content, 1, ${excerpt}) AS excerpt,


### PR DESCRIPTION
## Summary
- add persistent snowflake identifiers to every domain table and ensure legacy rows are backfilled
- update page, comment, like, and import flows to emit snowflakes in admin webhook events
- adjust utilities and aggregation scripts to propagate the new identifiers consistently

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68d9df445170832196ec989bcca6ab6e