### PR TITLE
Fix internal link lookup and add admin pagination

### DIFF
--- a/views/admin/comments.ejs
+++ b/views/admin/comments.ejs
@@ -1,7 +1,7 @@
 <h1>Modération des commentaires</h1>
 
 <section class="card" style="margin-bottom:24px;">
-  <h2 style="margin-top:0;">En attente de validation (<%= pending.length %>)</h2>
+  <h2 style="margin-top:0;">En attente de validation (<%= pendingPagination.totalItems %>)</h2>
   <% if (!pending.length) { %>
     <p>Aucun commentaire en attente.</p>
   <% } else { %>
@@ -34,6 +34,32 @@
         </li>
       <% }) %>
     </ul>
+    <div class="table-footer" style="display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:0.75rem; margin-top:1rem;">
+      <form method="get" style="display:flex; align-items:center; gap:0.5rem;">
+        <label for="pending-per-page" style="white-space:nowrap;">Éléments par page</label>
+        <select id="pending-per-page" name="pendingPerPage" onchange="this.form.submit()">
+          <% pendingPagination.perPageOptions.forEach(option => { %>
+            <option value="<%= option %>" <%= option === pendingPagination.perPage ? 'selected' : '' %>><%= option %></option>
+          <% }) %>
+        </select>
+        <input type="hidden" name="pendingPage" value="1">
+        <input type="hidden" name="recentPage" value="<%= recentPagination.page %>">
+        <input type="hidden" name="recentPerPage" value="<%= recentPagination.perPage %>">
+      </form>
+      <span>Page <%= pendingPagination.page %> sur <%= pendingPagination.totalPages %></span>
+      <div style="display:flex; gap:0.5rem;">
+        <% if (pendingPagination.hasPrevious) { %>
+          <a class="btn" data-icon="⬅️" href="?pendingPage=<%= pendingPagination.previousPage %>&pendingPerPage=<%= pendingPagination.perPage %>&recentPage=<%= recentPagination.page %>&recentPerPage=<%= recentPagination.perPage %>">Précédent</a>
+        <% } else { %>
+          <span class="btn" data-icon="⬅️" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Précédent</span>
+        <% } %>
+        <% if (pendingPagination.hasNext) { %>
+          <a class="btn" data-icon="➡️" href="?pendingPage=<%= pendingPagination.nextPage %>&pendingPerPage=<%= pendingPagination.perPage %>&recentPage=<%= recentPagination.page %>&recentPerPage=<%= recentPagination.perPage %>">Suivant</a>
+        <% } else { %>
+          <span class="btn" data-icon="➡️" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Suivant</span>
+        <% } %>
+      </div>
+    </div>
   <% } %>
 </section>
 
@@ -65,5 +91,31 @@
         </li>
       <% }) %>
     </ul>
+    <div class="table-footer" style="display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:0.75rem; margin-top:1rem;">
+      <form method="get" style="display:flex; align-items:center; gap:0.5rem;">
+        <label for="recent-per-page" style="white-space:nowrap;">Éléments par page</label>
+        <select id="recent-per-page" name="recentPerPage" onchange="this.form.submit()">
+          <% recentPagination.perPageOptions.forEach(option => { %>
+            <option value="<%= option %>" <%= option === recentPagination.perPage ? 'selected' : '' %>><%= option %></option>
+          <% }) %>
+        </select>
+        <input type="hidden" name="recentPage" value="1">
+        <input type="hidden" name="pendingPage" value="<%= pendingPagination.page %>">
+        <input type="hidden" name="pendingPerPage" value="<%= pendingPagination.perPage %>">
+      </form>
+      <span>Page <%= recentPagination.page %> sur <%= recentPagination.totalPages %></span>
+      <div style="display:flex; gap:0.5rem;">
+        <% if (recentPagination.hasPrevious) { %>
+          <a class="btn" data-icon="⬅️" href="?recentPage=<%= recentPagination.previousPage %>&recentPerPage=<%= recentPagination.perPage %>&pendingPage=<%= pendingPagination.page %>&pendingPerPage=<%= pendingPagination.perPage %>">Précédent</a>
+        <% } else { %>
+          <span class="btn" data-icon="⬅️" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Précédent</span>
+        <% } %>
+        <% if (recentPagination.hasNext) { %>
+          <a class="btn" data-icon="➡️" href="?recentPage=<%= recentPagination.nextPage %>&recentPerPage=<%= recentPagination.perPage %>&pendingPage=<%= pendingPagination.page %>&pendingPerPage=<%= pendingPagination.perPage %>">Suivant</a>
+        <% } else { %>
+          <span class="btn" data-icon="➡️" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Suivant</span>
+        <% } %>
+      </div>
+    </div>
   <% } %>
 </section>

--- a/views/admin/ip_bans.ejs
+++ b/views/admin/ip_bans.ejs
@@ -34,7 +34,7 @@
 </section>
 
 <section class="card">
-  <h2>Blocages actifs</h2>
+  <h2>Blocages actifs (<%= activePagination.totalItems %>)</h2>
   <% if (!activeBans.length) { %>
     <p>Aucun blocage actif.</p>
   <% } else { %>
@@ -70,11 +70,37 @@
         </tbody>
       </table>
     </div>
+    <div class="table-footer" style="display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:0.75rem; margin-top:1rem;">
+      <form method="get" style="display:flex; align-items:center; gap:0.5rem;">
+        <label for="active-per-page" style="white-space:nowrap;">Éléments par page</label>
+        <select id="active-per-page" name="activePerPage" onchange="this.form.submit()">
+          <% activePagination.perPageOptions.forEach(option => { %>
+            <option value="<%= option %>" <%= option === activePagination.perPage ? 'selected' : '' %>><%= option %></option>
+          <% }) %>
+        </select>
+        <input type="hidden" name="activePage" value="1">
+        <input type="hidden" name="liftedPage" value="<%= liftedPagination.page %>">
+        <input type="hidden" name="liftedPerPage" value="<%= liftedPagination.perPage %>">
+      </form>
+      <span>Page <%= activePagination.page %> sur <%= activePagination.totalPages %></span>
+      <div style="display:flex; gap:0.5rem;">
+        <% if (activePagination.hasPrevious) { %>
+          <a class="btn" data-icon="⬅️" href="?activePage=<%= activePagination.previousPage %>&activePerPage=<%= activePagination.perPage %>&liftedPage=<%= liftedPagination.page %>&liftedPerPage=<%= liftedPagination.perPage %>">Précédent</a>
+        <% } else { %>
+          <span class="btn" data-icon="⬅️" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Précédent</span>
+        <% } %>
+        <% if (activePagination.hasNext) { %>
+          <a class="btn" data-icon="➡️" href="?activePage=<%= activePagination.nextPage %>&activePerPage=<%= activePagination.perPage %>&liftedPage=<%= liftedPagination.page %>&liftedPerPage=<%= liftedPagination.perPage %>">Suivant</a>
+        <% } else { %>
+          <span class="btn" data-icon="➡️" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Suivant</span>
+        <% } %>
+      </div>
+    </div>
   <% } %>
 </section>
 
 <section class="card">
-  <h2>Blocages levés</h2>
+  <h2>Blocages levés (<%= liftedPagination.totalItems %>)</h2>
   <% if (!liftedBans.length) { %>
     <p>Aucun blocage levé enregistré.</p>
   <% } else { %>
@@ -105,6 +131,32 @@
           <% }) %>
         </tbody>
       </table>
+    </div>
+    <div class="table-footer" style="display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:0.75rem; margin-top:1rem;">
+      <form method="get" style="display:flex; align-items:center; gap:0.5rem;">
+        <label for="lifted-per-page" style="white-space:nowrap;">Éléments par page</label>
+        <select id="lifted-per-page" name="liftedPerPage" onchange="this.form.submit()">
+          <% liftedPagination.perPageOptions.forEach(option => { %>
+            <option value="<%= option %>" <%= option === liftedPagination.perPage ? 'selected' : '' %>><%= option %></option>
+          <% }) %>
+        </select>
+        <input type="hidden" name="liftedPage" value="1">
+        <input type="hidden" name="activePage" value="<%= activePagination.page %>">
+        <input type="hidden" name="activePerPage" value="<%= activePagination.perPage %>">
+      </form>
+      <span>Page <%= liftedPagination.page %> sur <%= liftedPagination.totalPages %></span>
+      <div style="display:flex; gap:0.5rem;">
+        <% if (liftedPagination.hasPrevious) { %>
+          <a class="btn" data-icon="⬅️" href="?liftedPage=<%= liftedPagination.previousPage %>&liftedPerPage=<%= liftedPagination.perPage %>&activePage=<%= activePagination.page %>&activePerPage=<%= activePagination.perPage %>">Précédent</a>
+        <% } else { %>
+          <span class="btn" data-icon="⬅️" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Précédent</span>
+        <% } %>
+        <% if (liftedPagination.hasNext) { %>
+          <a class="btn" data-icon="➡️" href="?liftedPage=<%= liftedPagination.nextPage %>&liftedPerPage=<%= liftedPagination.perPage %>&activePage=<%= activePagination.page %>&activePerPage=<%= activePagination.perPage %>">Suivant</a>
+        <% } else { %>
+          <span class="btn" data-icon="➡️" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Suivant</span>
+        <% } %>
+      </div>
     </div>
   <% } %>
 </section>

--- a/views/admin/uploads.ejs
+++ b/views/admin/uploads.ejs
@@ -67,6 +67,30 @@
       </tbody>
     </table>
   </div>
+  <div class="table-footer" style="display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:0.75rem; margin-top:1rem;">
+    <form method="get" style="display:flex; align-items:center; gap:0.5rem;">
+      <label for="uploads-per-page" style="white-space:nowrap;">Éléments par page</label>
+      <select id="uploads-per-page" name="perPage" onchange="this.form.submit()">
+        <% pagination.perPageOptions.forEach(option => { %>
+          <option value="<%= option %>" <%= option === pagination.perPage ? 'selected' : '' %>><%= option %></option>
+        <% }) %>
+      </select>
+      <input type="hidden" name="page" value="1">
+    </form>
+    <span>Page <%= pagination.page %> sur <%= pagination.totalPages %></span>
+    <div style="display:flex; gap:0.5rem;">
+      <% if (pagination.hasPrevious) { %>
+        <a class="btn" data-icon="⬅️" href="?page=<%= pagination.previousPage %>&perPage=<%= pagination.perPage %>">Précédent</a>
+      <% } else { %>
+        <span class="btn" data-icon="⬅️" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Précédent</span>
+      <% } %>
+      <% if (pagination.hasNext) { %>
+        <a class="btn" data-icon="➡️" href="?page=<%= pagination.nextPage %>&perPage=<%= pagination.perPage %>">Suivant</a>
+      <% } else { %>
+        <span class="btn" data-icon="➡️" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Suivant</span>
+      <% } %>
+    </div>
+  </div>
 <% } else { %>
   <p class="card" style="color:var(--muted)">Aucune image disponible pour le moment.</p>
 <% } %>

--- a/views/admin/users.ejs
+++ b/views/admin/users.ejs
@@ -7,20 +7,50 @@
     <button class="btn success" data-icon="➕">Ajouter</button>
   </div>
 </form>
-<table class="data-table">
-  <thead><tr><th>ID</th><th>Nom</th><th>Admin</th><th></th></tr></thead>
-  <tbody>
-  <% users.forEach(u=>{ %>
-    <tr>
-      <td><%= u.id %></td>
-      <td><%= u.username %></td>
-      <td>Oui</td>
-      <td>
-        <form method="post" action="/admin/users/<%= u.id %>/delete" onsubmit="return confirm('Supprimer cet utilisateur ?')">
-          <button class="btn danger" data-icon="🗑️">Supprimer</button>
-        </form>
-      </td>
-    </tr>
-  <% }) %>
-  </tbody>
-</table>
+<% if (!users.length) { %>
+  <p class="card" style="margin-top:16px;">Aucun utilisateur trouvé.</p>
+<% } else { %>
+  <div class="table-wrap" style="margin-top:16px;">
+    <table class="data-table">
+      <thead><tr><th>ID</th><th>Nom</th><th>Admin</th><th></th></tr></thead>
+      <tbody>
+      <% users.forEach(u=>{ %>
+        <tr>
+          <td><%= u.id %></td>
+          <td><%= u.username %></td>
+          <td><%= u.is_admin ? 'Oui' : 'Non' %></td>
+          <td>
+            <form method="post" action="/admin/users/<%= u.id %>/delete" onsubmit="return confirm('Supprimer cet utilisateur ?')">
+              <button class="btn danger" data-icon="🗑️">Supprimer</button>
+            </form>
+          </td>
+        </tr>
+      <% }) %>
+      </tbody>
+    </table>
+  </div>
+  <div class="table-footer" style="display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:0.75rem; margin-top:1rem;">
+    <form method="get" style="display:flex; align-items:center; gap:0.5rem;">
+      <label for="users-per-page" style="white-space:nowrap;">Éléments par page</label>
+      <select id="users-per-page" name="perPage" onchange="this.form.submit()">
+        <% pagination.perPageOptions.forEach(option => { %>
+          <option value="<%= option %>" <%= option === pagination.perPage ? 'selected' : '' %>><%= option %></option>
+        <% }) %>
+      </select>
+      <input type="hidden" name="page" value="1">
+    </form>
+    <span>Page <%= pagination.page %> sur <%= pagination.totalPages %></span>
+    <div style="display:flex; gap:0.5rem;">
+      <% if (pagination.hasPrevious) { %>
+        <a class="btn" data-icon="⬅️" href="?page=<%= pagination.previousPage %>&perPage=<%= pagination.perPage %>">Précédent</a>
+      <% } else { %>
+        <span class="btn" data-icon="⬅️" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Précédent</span>
+      <% } %>
+      <% if (pagination.hasNext) { %>
+        <a class="btn" data-icon="➡️" href="?page=<%= pagination.nextPage %>&perPage=<%= pagination.perPage %>">Suivant</a>
+      <% } else { %>
+        <span class="btn" data-icon="➡️" aria-disabled="true" style="pointer-events:none; opacity:0.5;">Suivant</span>
+      <% } %>
+    </div>
+  </div>
+<% } %>


### PR DESCRIPTION
## Summary
- ensure [[...]] internal links resolve to the latest matching page slug with additional fallbacks
- add configurable pagination controls to admin comments, IP bans, uploads, and users views using shared page-size options

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e217b5c4832187534c9deea39343