### PR TITLE
Fix feed webhook markdown formatting

### DIFF
--- a/utils/articleFormatter.js
+++ b/utils/articleFormatter.js
@@ -16,6 +16,30 @@ turndown.addRule("strikethrough", {
   replacement: (content) => `~~${content}~~`,
 });
 
+turndown.addRule("fencedCodeBlockWithLanguage", {
+  filter: (node) =>
+    node.nodeName === "PRE" &&
+    node.firstChild &&
+    node.firstChild.nodeName === "CODE",
+  replacement: (_content, node) => {
+    const codeNode = node.firstChild;
+    const rawClassName = codeNode.getAttribute("class") || "";
+    const languageMatch = rawClassName.match(/(?:language|lang)-([\w+#-]+)/i);
+    let language = languageMatch ? languageMatch[1].toLowerCase() : "";
+    language = language.replace(/[^a-z0-9+#-]/g, "");
+    if (language === "javascript") language = "js";
+    if (language === "typescript") language = "ts";
+    if (language === "c++") language = "cpp";
+    if (language === "c#") language = "csharp";
+
+    const codeText = codeNode.textContent || "";
+    const trimmed = codeText.replace(/^\n+/u, "").replace(/\s+$/u, "");
+    const openingFence = language ? "```" + language : "```";
+    const closingFence = "```";
+    return `\n\n${openingFence}\n${trimmed}\n${closingFence}\n\n`;
+  },
+});
+
 const CONTENT_SANITIZE_OPTIONS = {
   allowedTags: sanitizeHtml.defaults.allowedTags.concat([
     "h1",

--- a/utils/webhook.js
+++ b/utils/webhook.js
@@ -54,14 +54,15 @@ function formatMetaLines(meta) {
     .filter(Boolean);
 }
 
-function formatPageSummary(page, url) {
+function formatPageSummary(page, url, options = {}) {
   if (!page) return "";
+  const { includeTitle = true, includeLink = true } = options;
   const lines = [];
-  if (page.title) {
+  if (page.title && includeTitle) {
     lines.push(`**Titre :** ${page.title}`);
   }
   const link = url || (page.slug_id ? `/wiki/${page.slug_id}` : "");
-  if (link) {
+  if (link && includeLink) {
     lines.push(`**Lien :** ${link}`);
   } else if (page.slug_id) {
     lines.push(`**Identifiant :** ${page.slug_id}`);
@@ -117,7 +118,23 @@ async function sendEvent(channel, title, data = {}, options = {}) {
     sections.push(descriptionSeed);
   }
 
-  const pageSummary = formatPageSummary(data?.page, data?.url);
+  const normalizedDescription =
+    typeof descriptionSeed === "string" ? descriptionSeed.toLowerCase() : "";
+  const normalizedTitle =
+    typeof data?.page?.title === "string" ? data.page.title.toLowerCase() : "";
+  const descriptionContainsTitle =
+    normalizedDescription && normalizedTitle
+      ? normalizedDescription.includes(normalizedTitle)
+      : false;
+  const descriptionContainsUrl =
+    Boolean(descriptionSeed) && Boolean(data?.url)
+      ? descriptionSeed.includes(data.url)
+      : false;
+
+  const pageSummary = formatPageSummary(data?.page, data?.url, {
+    includeTitle: !descriptionContainsTitle,
+    includeLink: !descriptionContainsUrl,
+  });
   if (pageSummary) {
     sections.push(pageSummary);
   }


### PR DESCRIPTION
## Summary
- avoid duplicating page title and link in feed webhook embeds when the description already includes them
- ensure article markdown conversion preserves fenced code blocks with the appropriate language hint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e51e18c08321876c2aaadf4a2ee4