### PR TITLE
Harmonise la pagination des listes

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -22,14 +22,16 @@ import {
 import { banIp, liftBan } from "../utils/ipBans.js";
 import { getClientIp } from "../utils/ip.js";
 import {
+  DEFAULT_PAGE_SIZE,
+  PAGE_SIZE_OPTIONS,
+  resolvePageSize,
+} from "../utils/pagination.js";
+import {
   getSiteSettingsForForm,
   updateSiteSettingsFromForm,
   invalidateSiteSettingsCache,
 } from "../utils/settingsService.js";
 import { pushNotification } from "../utils/notifications.js";
-
-const PAGE_SIZE_OPTIONS = [5, 10, 50, 100, 500];
-const DEFAULT_PAGE_SIZE = 10;
 
 await ensureUploadDir();
 
@@ -1718,10 +1720,7 @@ function buildPagination(req, totalItems, options = {}) {
   let page =
     Number.isInteger(requestedPage) && requestedPage > 0 ? requestedPage : 1;
 
-  const requestedPerPage = Number.parseInt(req.query[perPageParam], 10);
-  const perPage = PAGE_SIZE_OPTIONS.includes(requestedPerPage)
-    ? requestedPerPage
-    : DEFAULT_PAGE_SIZE;
+  const perPage = resolvePageSize(req.query[perPageParam], DEFAULT_PAGE_SIZE);
 
   const totalPages = Math.max(1, Math.ceil(totalItems / perPage));
 

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -32,6 +32,11 @@ import {
   validateCommentBody,
 } from "../utils/commentValidation.js";
 import { buildPreviewHtml } from "../utils/htmlPreview.js";
+import {
+  DEFAULT_PAGE_SIZE,
+  PAGE_SIZE_OPTIONS,
+  resolvePageSize,
+} from "../utils/pagination.js";
 
 const r = Router();
 
@@ -48,8 +53,6 @@ r.use(
   }),
 );
 
-const PAGE_SIZE_OPTIONS = [5, 10, 50, 100, 500];
-const DEFAULT_PAGE_SIZE = 50;
 const RECENT_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
 
 r.get(
@@ -59,10 +62,7 @@ r.get(
     const weekAgo = new Date(Date.now() - RECENT_LOOKBACK_MS).toISOString();
 
     const total = await countPages();
-    const requestedSize = parseInt(req.query.size || String(DEFAULT_PAGE_SIZE), 10);
-    const size = PAGE_SIZE_OPTIONS.includes(requestedSize)
-      ? requestedSize
-      : DEFAULT_PAGE_SIZE;
+    const size = resolvePageSize(req.query.size, DEFAULT_PAGE_SIZE);
     const totalPages = Math.max(1, Math.ceil(total / size));
     let page = parseInt(req.query.page || "1", 10);
     if (Number.isNaN(page) || page < 1) page = 1;

--- a/utils/pagination.js
+++ b/utils/pagination.js
@@ -1,0 +1,15 @@
+export const PAGE_SIZE_OPTIONS = [5, 10, 50, 100, 500];
+export const DEFAULT_PAGE_SIZE = 10;
+
+export function resolvePageSize(rawValue, defaultSize = DEFAULT_PAGE_SIZE) {
+  if (rawValue === undefined || rawValue === null || rawValue === "") {
+    return defaultSize;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (Number.isInteger(parsed) && PAGE_SIZE_OPTIONS.includes(parsed)) {
+    return parsed;
+  }
+
+  return defaultSize;
+}


### PR DESCRIPTION
## Summary
- factorise les paramètres de pagination dans un utilitaire partagé
- réutilise la même logique de taille de page pour les listes d’administration (commentaires, blocages IP, etc.)
- aligne la pagination de l’accueil sur les valeurs 5/10/50/100/500 avec un défaut cohérent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9eaaa7b548321bc79eec4f090644d