### PR TITLE
Add pagination to article comments and admin statistics tables

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -649,6 +649,16 @@ form .actions {
   gap: 0.5rem;
 }
 
+.comment-pagination .per-page-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.comment-pagination select {
+  min-width: 5rem;
+}
+
 /* === PAGE ARTICLE === */
 .page-header {
   margin-bottom: 24px;

--- a/utils/pagination.js
+++ b/utils/pagination.js
@@ -1,15 +1,137 @@
 export const PAGE_SIZE_OPTIONS = [5, 10, 50, 100, 500];
 export const DEFAULT_PAGE_SIZE = 10;
 
-export function resolvePageSize(rawValue, defaultSize = DEFAULT_PAGE_SIZE) {
+export function resolvePageSize(
+  rawValue,
+  defaultSize = DEFAULT_PAGE_SIZE,
+  allowedOptions = PAGE_SIZE_OPTIONS,
+) {
   if (rawValue === undefined || rawValue === null || rawValue === "") {
     return defaultSize;
   }
 
   const parsed = Number.parseInt(rawValue, 10);
-  if (Number.isInteger(parsed) && PAGE_SIZE_OPTIONS.includes(parsed)) {
+  if (Number.isInteger(parsed) && allowedOptions.includes(parsed)) {
     return parsed;
   }
 
   return defaultSize;
+}
+
+function firstQueryValue(value) {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+function buildQueryParams(query, exclude = []) {
+  const params = new URLSearchParams();
+  if (!query) {
+    return params;
+  }
+
+  const excluded = new Set(exclude);
+  for (const [key, rawValue] of Object.entries(query)) {
+    if (excluded.has(key)) continue;
+    const values = Array.isArray(rawValue) ? rawValue : [rawValue];
+    for (const value of values) {
+      if (value === undefined || value === null || value === "") continue;
+      params.append(key, String(value));
+    }
+  }
+
+  return params;
+}
+
+export function buildPagination(req, totalItems, options = {}) {
+  const {
+    pageParam = "page",
+    perPageParam = "perPage",
+    defaultPageSize = DEFAULT_PAGE_SIZE,
+    pageSizeOptions = PAGE_SIZE_OPTIONS,
+  } = options;
+
+  const query = req?.query || {};
+  const requestedPageRaw = firstQueryValue(query[pageParam]);
+  const requestedPage = Number.parseInt(requestedPageRaw, 10);
+  let page =
+    Number.isInteger(requestedPage) && requestedPage > 0 ? requestedPage : 1;
+
+  const perPage = resolvePageSize(
+    firstQueryValue(query[perPageParam]),
+    defaultPageSize,
+    pageSizeOptions,
+  );
+
+  const totalPages = Math.max(1, Math.ceil(totalItems / perPage));
+
+  if (page > totalPages) {
+    page = totalPages;
+  }
+
+  const hasPrevious = page > 1;
+  const hasNext = page < totalPages;
+
+  return {
+    page,
+    perPage,
+    totalItems,
+    totalPages,
+    hasPrevious,
+    hasNext,
+    previousPage: hasPrevious ? page - 1 : null,
+    nextPage: hasNext ? page + 1 : null,
+    perPageOptions: pageSizeOptions,
+  };
+}
+
+export function decoratePagination(req, pagination, options = {}) {
+  const { pageParam = "page", perPageParam = "perPage" } = options;
+  const preservedQuery = [];
+  if (req?.query) {
+    for (const [key, rawValue] of Object.entries(req.query)) {
+      if (key === pageParam || key === perPageParam) continue;
+      const values = Array.isArray(rawValue) ? rawValue : [rawValue];
+      for (const value of values) {
+        if (value === undefined || value === null || value === "") continue;
+        preservedQuery.push({ name: key, value: String(value) });
+      }
+    }
+  }
+
+  const baseParams = buildQueryParams(req?.query, [pageParam, perPageParam]);
+
+  const buildUrl = (pageValue) => {
+    const params = new URLSearchParams(baseParams.toString());
+    params.set(pageParam, String(pageValue));
+    params.set(perPageParam, String(pagination.perPage));
+    return `?${params.toString()}`;
+  };
+
+  const perPageOptionLinks = pagination.perPageOptions.map((option) => {
+    const params = new URLSearchParams(baseParams.toString());
+    params.set(pageParam, "1");
+    params.set(perPageParam, String(option));
+    return {
+      value: option,
+      selected: option === pagination.perPage,
+      url: `?${params.toString()}`,
+    };
+  });
+
+  return {
+    ...pagination,
+    pageParam,
+    perPageParam,
+    previousUrl: pagination.hasPrevious ? buildUrl(pagination.previousPage) : null,
+    nextUrl: pagination.hasNext ? buildUrl(pagination.nextPage) : null,
+    perPageOptionLinks,
+    preservedQuery,
+  };
+}
+
+export function buildPaginationView(req, totalItems, options = {}) {
+  const pagination = buildPagination(req, totalItems, options);
+  return decoratePagination(req, pagination, options);
 }

--- a/views/admin/paginationControls.ejs
+++ b/views/admin/paginationControls.ejs
@@ -1,0 +1,32 @@
+<% if (pagination && pagination.totalPages > 1) { %>
+  <div class="table-footer">
+    <form method="get">
+      <% const fieldId = `${pagination.pageParam}-per-page`; %>
+      <label for="<%= fieldId %>" class="nowrap">Éléments par page</label>
+      <select id="<%= fieldId %>" name="<%= pagination.perPageParam %>" onchange="this.form.submit()">
+        <% pagination.perPageOptions.forEach(option => { %>
+          <option value="<%= option %>" <%= option === pagination.perPage ? 'selected' : '' %>><%= option %></option>
+        <% }) %>
+      </select>
+      <input type="hidden" name="<%= pagination.pageParam %>" value="1">
+      <% if (pagination.preservedQuery && pagination.preservedQuery.length) { %>
+        <% pagination.preservedQuery.forEach(pair => { %>
+          <input type="hidden" name="<%= pair.name %>" value="<%= pair.value %>">
+        <% }) %>
+      <% } %>
+    </form>
+    <span>Page <%= pagination.page %> sur <%= pagination.totalPages %></span>
+    <div class="pager">
+      <% if (pagination.hasPrevious) { %>
+        <a class="btn" data-icon="⬅️" href="<%= pagination.previousUrl %>">Précédent</a>
+      <% } else { %>
+        <span class="btn" data-icon="⬅️" aria-disabled="true">Précédent</span>
+      <% } %>
+      <% if (pagination.hasNext) { %>
+        <a class="btn" data-icon="➡️" href="<%= pagination.nextUrl %>">Suivant</a>
+      <% } else { %>
+        <span class="btn" data-icon="➡️" aria-disabled="true">Suivant</span>
+      <% } %>
+    </div>
+  </div>
+<% } %>

--- a/views/admin/stats.ejs
+++ b/views/admin/stats.ejs
@@ -81,6 +81,7 @@
           </tbody>
         </table>
       </div>
+      <%- include('admin/paginationControls', { pagination: topLikedPagination }) %>
     <% } %>
   </div>
   <div>
@@ -106,6 +107,7 @@
           </tbody>
         </table>
       </div>
+      <%- include('admin/paginationControls', { pagination: topCommentersPagination }) %>
     <% } %>
   </div>
   <div>
@@ -133,6 +135,7 @@
           </tbody>
         </table>
       </div>
+      <%- include('admin/paginationControls', { pagination: topCommentedPagination }) %>
     <% } %>
   </div>
 </section>
@@ -162,6 +165,7 @@
         </tbody>
       </table>
     </div>
+    <%- include('admin/paginationControls', { pagination: activeIpsPagination }) %>
   <% } %>
 </section>
 
@@ -191,6 +195,7 @@
           </tbody>
         </table>
       </div>
+      <%- include('admin/paginationControls', { pagination: tagUsagePagination }) %>
     <% } %>
   </div>
   <div>
@@ -216,6 +221,7 @@
           </tbody>
         </table>
       </div>
+      <%- include('admin/paginationControls', { pagination: commentTimelinePagination }) %>
     <% } %>
   </div>
 </section>
@@ -247,6 +253,7 @@
         </tbody>
       </table>
     </div>
+    <%- include('admin/paginationControls', { pagination: ipViewsPagination }) %>
   <% } %>
 </section>
 

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -6,7 +6,7 @@
       <span>Créé: <%= page.created_at %></span>
       <% if (page.updated_at) { %><span>• Modifié: <%= page.updated_at %></span><% } %>
       <span>• Likes: <strong data-like-count-for="<%= page.slug_id %>"><%= page.likes %></strong></span>
-      <span>• Commentaires: <strong><%= comments.length %></strong></span>
+      <span>• Commentaires: <strong><%= commentPagination.totalItems %></strong></span>
       <span>• Vues: <strong><%= page.views %></strong></span>
     </div>
   </div>
@@ -75,6 +75,35 @@
     </ul>
   <% } else { %>
     <p class="comment-empty">Aucun commentaire pour le moment.</p>
+  <% } %>
+
+  <% if (commentPagination.totalPages > 1) { %>
+    <div class="table-footer comment-pagination">
+      <div class="per-page-control">
+        <label for="comments-per-page" class="nowrap">Commentaires par page</label>
+        <select
+          id="comments-per-page"
+          onchange="if (this.value) window.location.href = this.value;"
+        >
+          <% commentPagination.perPageOptionLinks.forEach(option => { %>
+            <option value="<%= option.url %>#comments" <%= option.selected ? 'selected' : '' %>><%= option.value %></option>
+          <% }) %>
+        </select>
+      </div>
+      <span>Page <%= commentPagination.page %> sur <%= commentPagination.totalPages %></span>
+      <div class="pager">
+        <% if (commentPagination.hasPrevious) { %>
+          <a class="btn" data-icon="⬅️" href="<%= commentPagination.previousUrl %>#comments">Précédent</a>
+        <% } else { %>
+          <span class="btn" data-icon="⬅️" aria-disabled="true">Précédent</span>
+        <% } %>
+        <% if (commentPagination.hasNext) { %>
+          <a class="btn" data-icon="➡️" href="<%= commentPagination.nextUrl %>#comments">Suivant</a>
+        <% } else { %>
+          <span class="btn" data-icon="➡️" aria-disabled="true">Suivant</span>
+        <% } %>
+      </div>
+    </div>
   <% } %>
 
   <form class="comment-form" method="post" action="/wiki/<%= page.slug_id %>/comments">


### PR DESCRIPTION
## Summary
- add shared pagination utilities and paginate article comment threads with anchors back to the comment section
- paginate the admin statistics leaderboards using a reusable pagination partial
- tweak stylesheet rules to support the new front-end pagination controls

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d9ec5170f48321878815fb6142585e