### PR TITLE
Fix admin stats handler to use request object

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -335,7 +335,7 @@ r.get("/pages", async (req, res) => {
   });
 });
 
-r.get("/stats", async (_req, res) => {
+r.get("/stats", async (req, res) => {
   const periods = [
     {
       key: "day",


### PR DESCRIPTION
## Summary
- fix the admin stats route to receive the request object
- ensure pagination helpers can access query parameters without throwing ReferenceError

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9f1b31f3c8321b1b484943897658c