### PR TITLE
Enable collaborative contributions with admin review

### DIFF
--- a/db.js
+++ b/db.js
@@ -98,6 +98,25 @@ export async function initDb() {
   );
   CREATE INDEX IF NOT EXISTS idx_comments_page_status
     ON comments(page_id, status);
+  CREATE TABLE IF NOT EXISTS page_submissions(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snowflake_id TEXT UNIQUE,
+    page_id INTEGER REFERENCES pages(id) ON DELETE SET NULL,
+    target_slug_id TEXT,
+    type TEXT NOT NULL CHECK(type IN ('create','edit')),
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    tags TEXT,
+    status TEXT NOT NULL DEFAULT 'pending'
+      CHECK(status IN ('pending','approved','rejected')),
+    ip TEXT,
+    submitted_by TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    reviewer_id INTEGER REFERENCES users(id),
+    review_note TEXT,
+    reviewed_at DATETIME,
+    result_slug_id TEXT
+  );
   CREATE TABLE IF NOT EXISTS ip_bans(
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     snowflake_id TEXT UNIQUE,
@@ -144,6 +163,7 @@ export async function initDb() {
   await ensureSnowflake("page_tags");
   await ensureSnowflake("likes");
   await ensureSnowflake("comments");
+  await ensureSnowflake("page_submissions");
   await ensureSnowflake("ip_bans");
   await ensureSnowflake("event_logs");
   await ensureSnowflake("uploads", "snowflake_id");

--- a/utils/pageEditing.js
+++ b/utils/pageEditing.js
@@ -1,0 +1,72 @@
+import { get, run } from "../db.js";
+import { generateSnowflake } from "./snowflake.js";
+
+export function normalizeTagInput(input = "") {
+  if (Array.isArray(input)) {
+    return Array.from(
+      new Set(
+        input
+          .map((value) => (typeof value === "string" ? value.trim() : ""))
+          .filter(Boolean)
+          .map((value) => value.toLowerCase()),
+      ),
+    );
+  }
+
+  if (typeof input !== "string") {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      input
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .map((value) => value.toLowerCase()),
+    ),
+  );
+}
+
+export async function upsertTags(pageId, input = "") {
+  const names = normalizeTagInput(input);
+  if (!pageId) {
+    return names;
+  }
+
+  for (const name of names) {
+    await run("INSERT OR IGNORE INTO tags(name, snowflake_id) VALUES(?,?)", [
+      name,
+      generateSnowflake(),
+    ]);
+    const tag = await get("SELECT id FROM tags WHERE name=?", [name]);
+    if (!tag?.id) {
+      continue;
+    }
+    await run(
+      "INSERT OR IGNORE INTO page_tags(snowflake_id, page_id, tag_id) VALUES(?,?,?)",
+      [generateSnowflake(), pageId, tag.id],
+    );
+  }
+
+  return names;
+}
+
+export async function recordRevision(pageId, title, content, authorId = null) {
+  if (!pageId) {
+    return null;
+  }
+
+  const row = await get(
+    "SELECT COALESCE(MAX(revision), 0) + 1 AS next FROM page_revisions WHERE page_id=?",
+    [pageId],
+  );
+  const next = row?.next || 1;
+  const snowflake = generateSnowflake();
+  await run(
+    "INSERT INTO page_revisions(snowflake_id, page_id, revision, title, content, author_id) VALUES(?,?,?,?,?,?)",
+    [snowflake, pageId, next, title, content, authorId],
+  );
+  return next;
+}
+

--- a/views/admin/ip_bans.ejs
+++ b/views/admin/ip_bans.ejs
@@ -15,6 +15,7 @@
         <option value="view">Blocage des vues</option>
         <option value="comment">Commentaires</option>
         <option value="like">Likes</option>
+        <option value="contribute">Contributions</option>
         <option value="tag">Tag spécifique</option>
       </select>
     </div>
@@ -30,7 +31,7 @@
       <button class="btn success" data-icon="🛡️" type="submit">Enregistrer</button>
     </div>
   </form>
-  <p class="help-text">Pour un blocage limité à une action, choisissez la portée correspondante. Pour interdire l'accès à un tag, indiquez "tag" puis le nom du tag.</p>
+  <p class="help-text">Pour un blocage limité à une action, choisissez la portée correspondante (vues, commentaires, likes ou contributions). Pour interdire l'accès à un tag, indiquez "tag" puis le nom du tag.</p>
 </section>
 
 <section class="card">

--- a/views/admin/submission_detail.ejs
+++ b/views/admin/submission_detail.ejs
@@ -1,0 +1,106 @@
+<% title = 'Contribution'; %>
+<h1>Contribution <code><%= submission.snowflake_id %></code></h1>
+
+<section class="card mb-xl">
+  <h2>Informations</h2>
+  <div class="grid grid-auto">
+    <div>
+      <strong>Type</strong>
+      <p><%= submission.type === 'edit' ? 'Modification' : 'Création' %></p>
+    </div>
+    <div>
+      <strong>Titre proposé</strong>
+      <p><strong><%= submission.title %></strong></p>
+    </div>
+    <div>
+      <strong>IP</strong>
+      <p><%= submission.ip || '–' %></p>
+    </div>
+    <div>
+      <strong>Proposé le</strong>
+      <p><%= new Date(submission.created_at).toLocaleString('fr-FR') %></p>
+    </div>
+    <div>
+      <strong>Statut</strong>
+      <p>
+        <% if (submission.status === 'pending') { %>
+          En attente
+        <% } else if (submission.status === 'approved') { %>
+          Approuvée
+        <% } else { %>
+          Rejetée
+        <% } %>
+      </p>
+    </div>
+    <% if (submission.reviewed_at) { %>
+      <div>
+        <strong>Décision</strong>
+        <p>
+          <%= new Date(submission.reviewed_at).toLocaleString('fr-FR') %>
+          <% if (submission.reviewer_username) { %>
+            · par <strong><%= submission.reviewer_username %></strong>
+          <% } %>
+        </p>
+      </div>
+    <% } %>
+    <% if (submission.review_note) { %>
+      <div>
+        <strong>Note</strong>
+        <p><%= submission.review_note %></p>
+      </div>
+    <% } %>
+    <div>
+      <strong>Tags proposés</strong>
+      <p>
+        <% if (proposedTags.length) { %>
+          <%= proposedTags.join(', ') %>
+        <% } else { %>
+          –
+        <% } %>
+      </p>
+    </div>
+    <% if (currentTags && currentTags.length) { %>
+      <div>
+        <strong>Tags actuels</strong>
+        <p><%= currentTags.join(', ') %></p>
+      </div>
+    <% } %>
+    <% if (submission.current_slug) { %>
+      <div>
+        <strong>Page actuelle</strong>
+        <p><a href="/wiki/<%= submission.current_slug %>"><code><%= submission.current_slug %></code></a></p>
+      </div>
+    <% } %>
+  </div>
+</section>
+
+<% if (submission.status === 'pending') { %>
+  <section class="card mb-xl">
+    <h2>Prendre une décision</h2>
+    <div class="grid grid-auto">
+      <form method="post" action="/admin/submissions/<%= submission.snowflake_id %>/approve" class="flex flex-col gap-sm">
+        <label for="approve-note">Note (optionnelle)</label>
+        <textarea id="approve-note" name="note" rows="3" placeholder="Commentaire interne"></textarea>
+        <button class="btn success" data-icon="✅" type="submit">Approuver la contribution</button>
+      </form>
+      <form method="post" action="/admin/submissions/<%= submission.snowflake_id %>/reject" class="flex flex-col gap-sm" onsubmit="return confirm('Rejeter cette contribution ?');">
+        <label for="reject-note">Motif (optionnel)</label>
+        <textarea id="reject-note" name="note" rows="3" placeholder="Motif du rejet"></textarea>
+        <button class="btn danger" data-icon="✖️" type="submit">Rejeter la contribution</button>
+      </form>
+    </div>
+  </section>
+<% } %>
+
+<section class="card mb-xl">
+  <h2>Contenu proposé</h2>
+  <div class="prose"><div><%- proposedHtml %></div></div>
+</section>
+
+<% if (currentHtml) { %>
+  <section class="card">
+    <h2>Contenu actuel</h2>
+    <div class="prose"><div><%- currentHtml %></div></div>
+  </section>
+<% } %>
+

--- a/views/admin/submissions.ejs
+++ b/views/admin/submissions.ejs
@@ -1,0 +1,110 @@
+<% title = 'Contributions'; %>
+<h1>Contributions des visiteurs</h1>
+
+<section class="card mb-xl">
+  <h2>En attente (<%= pendingPagination.totalItems %>)</h2>
+  <% if (!pending.length) { %>
+    <p>Aucune contribution en attente de validation.</p>
+  <% } else { %>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Type</th>
+            <th>Titre</th>
+            <th>Page liée</th>
+            <th>Tags</th>
+            <th>IP</th>
+            <th>Créé</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% pending.forEach(item => { %>
+            <tr>
+              <td><code><%= item.snowflake_id %></code></td>
+              <td><%= item.type === 'edit' ? 'Modification' : 'Création' %></td>
+              <td><strong><%= item.title %></strong></td>
+              <td>
+                <% if (item.current_slug) { %>
+                  <a href="/wiki/<%= item.current_slug %>"><code><%= item.current_slug %></code></a>
+                <% } else { %>
+                  –
+                <% } %>
+              </td>
+              <td>
+                <% if (item.tag_list && item.tag_list.length) { %>
+                  <%= item.tag_list.join(', ') %>
+                <% } else { %>
+                  –
+                <% } %>
+              </td>
+              <td><%= item.ip || '–' %></td>
+              <td><%= new Date(item.created_at).toLocaleString('fr-FR') %></td>
+              <td>
+                <a class="btn" data-icon="🔍" href="/admin/submissions/<%= item.snowflake_id %>">Voir</a>
+                <form method="post" action="/admin/submissions/<%= item.snowflake_id %>/approve">
+                  <button class="btn success" data-icon="✅" type="submit">Approuver</button>
+                </form>
+                <form method="post" action="/admin/submissions/<%= item.snowflake_id %>/reject" onsubmit="return confirm('Rejeter cette contribution ?');">
+                  <button class="btn danger" data-icon="✖️" type="submit">Rejeter</button>
+                </form>
+              </td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+    <%- include('admin/paginationControls', { pagination: pendingPagination }) %>
+  <% } %>
+</section>
+
+<section class="card">
+  <h2>Historique des décisions (<%= recentPagination.totalItems %>)</h2>
+  <% if (!recent.length) { %>
+    <p>Aucune décision enregistrée.</p>
+  <% } else { %>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Type</th>
+            <th>Titre</th>
+            <th>Statut</th>
+            <th>Validé par</th>
+            <th>Revue</th>
+            <th>Note</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% recent.forEach(item => { %>
+            <tr>
+              <td><code><%= item.snowflake_id %></code></td>
+              <td><%= item.type === 'edit' ? 'Modification' : 'Création' %></td>
+              <td>
+                <strong><%= item.title %></strong>
+                <% if (item.result_slug_id) { %>
+                  <div><a href="/wiki/<%= item.result_slug_id %>"><code><%= item.result_slug_id %></code></a></div>
+                <% } %>
+              </td>
+              <td class="status <%= item.status %>"><%= item.status === 'approved' ? 'Approuvée' : 'Rejetée' %></td>
+              <td><%= item.reviewer_username || '–' %></td>
+              <td>
+                <% if (item.reviewed_at) { %>
+                  <%= new Date(item.reviewed_at).toLocaleString('fr-FR') %>
+                <% } else { %>
+                  –
+                <% } %>
+              </td>
+              <td><%= item.review_note ? item.review_note : '–' %></td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+    <%- include('admin/paginationControls', { pagination: recentPagination }) %>
+  <% } %>
+</section>
+

--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -1,5 +1,13 @@
 <% title = page ? 'Éditer' : 'Nouvelle page'; %>
 <h1><%= title %></h1>
+<% const isSubmission = typeof submissionMode !== 'undefined' ? submissionMode : false; %>
+<% if (isSubmission) { %>
+  <div class="card card-highlight mb-md">
+    <p class="mt-0 mb-0">
+      Votre proposition sera enregistrée avec votre adresse IP et un administrateur devra la valider avant publication.
+    </p>
+  </div>
+<% } %>
 <form method="post">
   <label>Titre</label>
   <input type="text" name="title" value="<%= page ? page.title : '' %>" required />
@@ -44,7 +52,7 @@
       data-html-editor
       data-target="#contentField"
       data-toolbar="#editorToolbar"
-      data-upload-endpoint="/admin/uploads"
+      <% if (typeof allowUploads !== 'undefined' && allowUploads) { %>data-upload-endpoint="/admin/uploads"<% } %>
       aria-label="Éditeur de contenu"
     ></div>
   </div>
@@ -54,7 +62,11 @@
   <label>Tags (séparés par des virgules)</label>
   <input type="text" name="tags" value="<%= tags %>" />
   <div class="actions">
-    <button class="btn success" data-icon="💾" type="submit">Enregistrer</button>
+    <% if (isSubmission) { %>
+      <button class="btn success" data-icon="📨" type="submit">Envoyer ma proposition</button>
+    <% } else { %>
+      <button class="btn success" data-icon="💾" type="submit">Enregistrer</button>
+    <% } %>
   </div>
 </form>
 

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -42,8 +42,12 @@
     <nav class="vnav" id="vnav">
       <a href="/">🏠 Accueil</a>
       <a href="/rss.xml">📰 Flux RSS</a>
+      <% if (!currentUser || !currentUser.is_admin) { %>
+        <a href="/new">✍️ Contribuer</a>
+      <% } %>
       <% if (currentUser && currentUser.is_admin) { %>
         <a href="/new">➕ Nouvelle page</a>
+        <a href="/admin/submissions">📝 Contributions</a>
         <a href="/admin/pages">📄 Articles</a>
         <a href="/admin/stats">📈 Statistiques</a>
         <a href="/admin/users">👤 Utilisateurs</a>

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -24,13 +24,16 @@
     </form>
     <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= page.slug_id %>')">Copier le lien</button>
     <% const currentUser = typeof user !== 'undefined' && user ? user : null; %>
-    <% if (currentUser && currentUser.is_admin) { %>
+    <% const isAdmin = currentUser && currentUser.is_admin; %>
+    <% if (isAdmin) { %>
       <a class="btn" data-icon="✏️" href="/edit/<%= page.slug_id %>">Éditer</a>
       <a class="btn" data-icon="📜" href="/wiki/<%= page.slug_id %>/history">Historique</a>
       <form action="/delete/<%= page.slug_id %>" method="post" onsubmit="return confirm('Supprimer ?')">
         <input type="hidden" name="_method" value="DELETE" />
         <button class="btn danger" data-icon="🗑️">Supprimer</button>
       </form>
+    <% } else { %>
+      <a class="btn" data-icon="✏️" href="/edit/<%= page.slug_id %>">Suggérer une modification</a>
     <% } %>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add a page_submissions table to capture pending contributions from unauthenticated visitors
- let visitors propose new pages or edits, logging their IPs, notifying admins, and gating actions behind IP bans when needed
- provide an admin contributions review interface with approval/rejection workflows that update content, tags, and feed notifications
- expose contribution entry points in the public and admin navigation and extend IP ban options for contribution blocking

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68da36f10bd48321b95b6568d7a35fd9