### PR TITLE
Fix submission notice contrast

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -165,10 +165,14 @@ body {
   color: #a60000;
 }
 
-.card-highlight {
+.card.card-highlight {
   background: #f4f6ff;
   border-color: #c7d2fe;
   color: #1e293b;
+}
+
+.card.card-highlight * {
+  color: inherit;
 }
 
 /* === TOPBAR === */


### PR DESCRIPTION
## Summary
- ensure highlighted cards override the base card styles so the submission notice uses the light background
- inherit the text color inside highlighted cards to keep the dark-on-light contrast intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da41e8e03883219b93e4630a63c59d