### PR TITLE
Colorize submission status indicators

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -759,6 +759,22 @@ form .actions {
   border-bottom: 1px solid #242a36;
 }
 
+.data-table td.status {
+  font-weight: 600;
+}
+
+.data-table td.status.approved {
+  color: var(--success);
+}
+
+.data-table td.status.pending {
+  color: var(--muted);
+}
+
+.data-table td.status.rejected {
+  color: var(--danger);
+}
+
 .data-table th code,
 .data-table td code {
   white-space: nowrap;
@@ -800,6 +816,35 @@ form .actions {
   border-color: rgba(237, 66, 69, 0.5);
   background: rgba(237, 66, 69, 0.14);
   color: #fecaca;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.status-pill.pending {
+  color: var(--muted);
+}
+
+.status-pill.approved {
+  color: var(--success);
+  border-color: rgba(87, 242, 135, 0.35);
+  background: rgba(87, 242, 135, 0.12);
+}
+
+.status-pill.rejected {
+  color: var(--danger);
+  border-color: rgba(237, 66, 69, 0.35);
+  background: rgba(237, 66, 69, 0.12);
 }
 
 .comments .comment-list,

--- a/views/admin/submission_detail.ejs
+++ b/views/admin/submission_detail.ejs
@@ -24,11 +24,11 @@
       <strong>Statut</strong>
       <p>
         <% if (submission.status === 'pending') { %>
-          En attente
+          <span class="status status-pill pending">En attente</span>
         <% } else if (submission.status === 'approved') { %>
-          Approuvée
+          <span class="status status-pill approved">Approuvée</span>
         <% } else { %>
-          Rejetée
+          <span class="status status-pill rejected">Rejetée</span>
         <% } %>
       </p>
     </div>


### PR DESCRIPTION
## Summary
- color-code submission history statuses to distinguish approvals and rejections
- add reusable pill styling for submission details to highlight the current status

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68da42f8cec48321914d67b25861ec25