### PR TITLE
Allow admins to reuse configured display names in comments

### DIFF
--- a/db.js
+++ b/db.js
@@ -17,6 +17,7 @@ export async function initDb() {
     snowflake_id TEXT UNIQUE,
     username TEXT UNIQUE NOT NULL,
     password TEXT NOT NULL,
+    display_name TEXT,
     is_admin INTEGER NOT NULL DEFAULT 1
   );
   CREATE TABLE IF NOT EXISTS settings(
@@ -153,6 +154,7 @@ export async function initDb() {
   await ensureColumn("comments", "ip", "TEXT");
   await ensureColumn("comments", "updated_at", "DATETIME");
   await ensureColumn("comments", "edit_token", "TEXT");
+  await ensureColumn("users", "display_name", "TEXT");
   await ensureSnowflake("settings");
   await ensureSnowflake("users");
   await ensureSnowflake("pages");

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -46,7 +46,12 @@ r.post("/login", async (req, res) => {
     const newHash = await hashPassword(password);
     await run("UPDATE users SET password=? WHERE id=?", [newHash, u.id]);
   }
-  req.session.user = { id: u.id, username: u.username, is_admin: !!u.is_admin };
+  req.session.user = {
+    id: u.id,
+    username: u.username,
+    is_admin: !!u.is_admin,
+    display_name: u.display_name || null,
+  };
   await sendAdminEvent(
     "Connexion réussie",
     {

--- a/views/admin/users.ejs
+++ b/views/admin/users.ejs
@@ -12,12 +12,26 @@
 <% } else { %>
   <div class="table-wrap mt-md">
     <table class="data-table">
-      <thead><tr><th>ID</th><th>Nom</th><th>Admin</th><th></th></tr></thead>
+      <thead><tr><th>ID</th><th>Nom</th><th>Pseudo commentaire</th><th>Admin</th><th></th></tr></thead>
       <tbody>
       <% users.forEach(u=>{ %>
         <tr>
           <td><%= u.id %></td>
           <td><%= u.username %></td>
+          <td>
+            <form method="post" action="/admin/users/<%= u.id %>/display-name" class="flex gap-sm items-center">
+              <input
+                type="text"
+                name="displayName"
+                maxlength="80"
+                value="<%= u.display_name || '' %>"
+                placeholder="Nom affiché"
+                aria-label="Pseudo pour <%= u.username %>"
+                class="flex-basis-220"
+              />
+              <button class="btn secondary" data-icon="💾" type="submit">Enregistrer</button>
+            </form>
+          </td>
           <td><%= u.is_admin ? 'Oui' : 'Non' %></td>
           <td>
             <form method="post" action="/admin/users/<%= u.id %>/delete" onsubmit="return confirm('Supprimer cet utilisateur ?')">

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -23,7 +23,7 @@
   </form>
   <div class="auth">
     <% if (currentUser) { %>
-      <div class="who">Connecté: <strong><%= currentUser.username %></strong></div>
+      <div class="who">Connecté: <strong><%= currentUser.display_name || currentUser.username %></strong></div>
       <form action="/logout" method="post"><button class="btn" data-icon="🔓">Déconnexion</button></form>
     <% } else { %>
       <a class="btn" data-icon="🔐" href="/login">Connexion</a>

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -53,7 +53,12 @@
   </div>
 <% } %>
 
+<% const commentUser = typeof user !== 'undefined' && user ? user : null; %>
+<% const adminPreferredName = commentUser && commentUser.is_admin
+  ? (commentUser.display_name || commentUser.username)
+  : null; %>
 <% const commentValues = (commentFeedback && commentFeedback.values) || {}; %>
+<% const commentAuthorValue = adminPreferredName || commentValues.author || ''; %>
 <section class="card comments" id="comments">
   <h2 class="mt-0">Commentaires</h2>
   <% if (comments && comments.length) { %>
@@ -110,10 +115,25 @@
   <% } %>
 
   <form class="comment-form" method="post" action="/wiki/<%= page.slug_id %>/comments">
-    <div class="field">
-      <label for="comment-author">Nom ou pseudo (facultatif)</label>
-      <input id="comment-author" type="text" name="author" maxlength="80" value="<%= commentValues.author || '' %>">
-    </div>
+    <% if (adminPreferredName) { %>
+      <div class="field">
+        <p class="text-muted">
+          Vous commentez en tant que <strong><%= commentAuthorValue %></strong>.
+        </p>
+        <input type="hidden" name="author" value="<%= commentAuthorValue %>">
+      </div>
+    <% } else { %>
+      <div class="field">
+        <label for="comment-author">Nom ou pseudo (facultatif)</label>
+        <input
+          id="comment-author"
+          type="text"
+          name="author"
+          maxlength="80"
+          value="<%= commentAuthorValue %>"
+        >
+      </div>
+    <% } %>
     <div class="field">
       <label for="comment-body">Votre message <span class="text-required">*</span></label>
       <textarea id="comment-body" name="body" rows="5" maxlength="2000" required><%= commentValues.body || '' %></textarea>


### PR DESCRIPTION
## Summary
- add a display name column for users and keep it in admin sessions
- let admins configure comment pseudonyms and auto-fill them when posting
- log display name updates and surface the chosen name in the UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da467d4af8832184cc024aabefce84