### PR TITLE
Add public IP profiles showing anonymous activity

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ import pagesRoutes from "./routes/pages.js";
 import searchRoutes from "./routes/search.js";
 import { getSiteSettings } from "./utils/settingsService.js";
 import { consumeNotifications } from "./utils/notifications.js";
+import { getClientIp } from "./utils/ip.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -43,6 +44,7 @@ app.use(async (req, res, next) => {
     res.locals.logoUrl = settings.logoUrl;
     res.locals.footerText = settings.footerText;
     res.locals.notifications = consumeNotifications(req);
+    res.locals.canViewIpProfile = Boolean(getClientIp(req));
     next();
   } catch (err) {
     next(err);

--- a/db.js
+++ b/db.js
@@ -59,6 +59,14 @@ export async function initDb() {
   );
   CREATE INDEX IF NOT EXISTS idx_page_views_page ON page_views(page_id);
   CREATE INDEX IF NOT EXISTS idx_page_views_page_date ON page_views(page_id, viewed_at);
+  CREATE TABLE IF NOT EXISTS ip_profiles(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snowflake_id TEXT UNIQUE,
+    ip TEXT UNIQUE NOT NULL,
+    hash TEXT UNIQUE NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
   CREATE TABLE IF NOT EXISTS page_view_daily(
     page_id INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
     day TEXT NOT NULL,
@@ -167,6 +175,7 @@ export async function initDb() {
   await ensureSnowflake("comments");
   await ensureSnowflake("page_submissions");
   await ensureSnowflake("ip_bans");
+  await ensureSnowflake("ip_profiles");
   await ensureSnowflake("event_logs");
   await ensureSnowflake("uploads", "snowflake_id");
   return db;

--- a/public/style.css
+++ b/public/style.css
@@ -872,6 +872,17 @@ form .actions {
   margin-bottom: 8px;
 }
 
+.comment-meta .comment-ip-profile {
+  color: var(--primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.comment-meta .comment-ip-profile:hover,
+.comment-meta .comment-ip-profile:focus {
+  text-decoration: underline;
+}
+
 .comment-body {
   white-space: pre-wrap;
   line-height: 1.7;
@@ -932,6 +943,11 @@ form .actions {
   gap: 8px;
 }
 
+.stat-grid .stat-sub {
+  font-size: 0.9em;
+  color: var(--muted);
+}
+
 .stat-grid .label {
   font-size: 0.85em;
   color: #94a3b8;
@@ -977,6 +993,101 @@ form .actions {
 
 .admin-comment-list.compact li {
   padding: 14px;
+}
+
+/* === IP PROFILES === */
+
+.ip-profile-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.ip-profile-header p {
+  margin: 0.35rem 0 0;
+}
+
+.ip-profile-owner-note {
+  background: rgba(79, 109, 251, 0.12);
+  border: 1px solid rgba(79, 109, 251, 0.35);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  color: var(--text);
+}
+
+.ip-profile-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.ip-profile-details div {
+  background: rgba(148, 163, 184, 0.1);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+.ip-profile-details dt {
+  margin: 0 0 0.25rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.ip-profile-details dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.ip-profile-stats {
+  margin: 0;
+}
+
+.ip-profile-stat strong {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.ip-profile-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ip-profile-activity {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ip-profile-activity li {
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.ip-profile-activity-meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.ip-profile-activity-meta time {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.ip-profile-activity-text {
+  margin: 0.5rem 0 0;
 }
 
 .admin-comment-list .status {

--- a/utils/ipProfiles.js
+++ b/utils/ipProfiles.js
@@ -1,0 +1,250 @@
+import { createHash } from "crypto";
+import { all, get, run } from "../db.js";
+import { generateSnowflake } from "./snowflake.js";
+
+const SALT = process.env.IP_PROFILE_SALT || "simple-wiki-ip-profile::v1";
+
+function normalizeIp(input) {
+  if (typeof input !== "string") {
+    return "";
+  }
+  return input.trim();
+}
+
+export function hashIp(ip) {
+  const normalized = normalizeIp(ip);
+  if (!normalized) {
+    return null;
+  }
+  return createHash("sha256")
+    .update(`${SALT}:${normalized}`)
+    .digest("hex");
+}
+
+export function formatIpProfileLabel(hash, length = 10) {
+  if (!hash) {
+    return null;
+  }
+  const safeLength = Number.isInteger(length) && length > 3 ? length : 10;
+  return hash.slice(0, safeLength).toUpperCase();
+}
+
+export async function touchIpProfile(ip) {
+  const normalized = normalizeIp(ip);
+  if (!normalized) {
+    return null;
+  }
+  const hashed = hashIp(normalized);
+  if (!hashed) {
+    return null;
+  }
+
+  const existing = await get(
+    "SELECT id, hash FROM ip_profiles WHERE ip = ?",
+    [normalized],
+  );
+  if (existing?.id) {
+    await run("UPDATE ip_profiles SET last_seen_at=CURRENT_TIMESTAMP WHERE id=?", [
+      existing.id,
+    ]);
+    return {
+      hash: existing.hash,
+      shortHash: formatIpProfileLabel(existing.hash),
+    };
+  }
+
+  const snowflake = generateSnowflake();
+  try {
+    await run(
+      "INSERT INTO ip_profiles(snowflake_id, ip, hash) VALUES(?,?,?)",
+      [snowflake, normalized, hashed],
+    );
+  } catch (err) {
+    if (err?.code !== "SQLITE_CONSTRAINT_UNIQUE") {
+      throw err;
+    }
+  }
+
+  const created = await get(
+    "SELECT hash FROM ip_profiles WHERE ip = ?",
+    [normalized],
+  );
+  const finalHash = created?.hash || hashed;
+  if (created?.hash) {
+    await run(
+      "UPDATE ip_profiles SET last_seen_at=CURRENT_TIMESTAMP WHERE ip=?",
+      [normalized],
+    );
+  }
+  return {
+    hash: finalHash,
+    shortHash: formatIpProfileLabel(finalHash),
+  };
+}
+
+export async function getIpProfileByHash(hash) {
+  const normalized = normalizeIp(hash);
+  if (!normalized) {
+    return null;
+  }
+
+  const profile = await get(
+    `SELECT id, ip, hash, created_at, last_seen_at
+       FROM ip_profiles
+      WHERE hash = ?`,
+    [normalized],
+  );
+
+  if (!profile?.ip) {
+    return null;
+  }
+
+  const [viewStats, likeStats, commentStats, submissionStats, submissionBreakdown, recentComments, recentLikes, recentViews, recentSubmissions] =
+    await Promise.all([
+      get(
+        `SELECT COUNT(*) AS total, COUNT(DISTINCT page_id) AS unique_pages, MAX(viewed_at) AS last_at
+           FROM page_views
+          WHERE ip = ?`,
+        [profile.ip],
+      ),
+      get(
+        `SELECT COUNT(*) AS total, COUNT(DISTINCT page_id) AS unique_pages, MAX(created_at) AS last_at
+           FROM likes
+          WHERE ip = ?`,
+        [profile.ip],
+      ),
+      get(
+        `SELECT COUNT(*) AS total, MAX(created_at) AS last_at
+           FROM comments
+          WHERE ip = ? AND status='approved'`,
+        [profile.ip],
+      ),
+      get(
+        `SELECT COUNT(*) AS total, MAX(created_at) AS last_at
+           FROM page_submissions
+          WHERE ip = ?`,
+        [profile.ip],
+      ),
+      all(
+        `SELECT status, COUNT(*) AS total
+           FROM page_submissions
+          WHERE ip = ?
+          GROUP BY status`,
+        [profile.ip],
+      ),
+      all(
+        `SELECT c.snowflake_id, c.body, c.created_at, p.title, p.slug_id
+           FROM comments c
+           JOIN pages p ON p.id = c.page_id
+          WHERE c.ip = ? AND c.status='approved'
+          ORDER BY c.created_at DESC
+          LIMIT 5`,
+        [profile.ip],
+      ),
+      all(
+        `SELECT l.snowflake_id, l.created_at, p.title, p.slug_id
+           FROM likes l
+           JOIN pages p ON p.id = l.page_id
+          WHERE l.ip = ?
+          ORDER BY l.created_at DESC
+          LIMIT 5`,
+        [profile.ip],
+      ),
+      all(
+        `SELECT v.snowflake_id, v.viewed_at, p.title, p.slug_id
+           FROM page_views v
+           JOIN pages p ON p.id = v.page_id
+          WHERE v.ip = ?
+          ORDER BY v.viewed_at DESC
+          LIMIT 5`,
+        [profile.ip],
+      ),
+      all(
+        `SELECT ps.snowflake_id, ps.title, ps.status, ps.type, ps.created_at, ps.result_slug_id,
+                ps.target_slug_id, p.slug_id AS current_slug, p.title AS current_title
+           FROM page_submissions ps
+           LEFT JOIN pages p ON p.id = ps.page_id
+          WHERE ps.ip = ?
+          ORDER BY ps.created_at DESC
+          LIMIT 5`,
+        [profile.ip],
+      ),
+    ]);
+
+  const submissionsByStatus = submissionBreakdown.reduce(
+    (acc, row) => ({
+      ...acc,
+      [row.status]: Number(row.total || 0),
+    }),
+    {},
+  );
+
+  return {
+    hash: profile.hash,
+    shortHash: formatIpProfileLabel(profile.hash),
+    createdAt: profile.created_at || null,
+    lastSeenAt: profile.last_seen_at || null,
+    stats: {
+      views: {
+        total: Number(viewStats?.total || 0),
+        uniquePages: Number(viewStats?.unique_pages || 0),
+        lastAt: viewStats?.last_at || null,
+      },
+      likes: {
+        total: Number(likeStats?.total || 0),
+        uniquePages: Number(likeStats?.unique_pages || 0),
+        lastAt: likeStats?.last_at || null,
+      },
+      comments: {
+        total: Number(commentStats?.total || 0),
+        lastAt: commentStats?.last_at || null,
+      },
+      submissions: {
+        total: Number(submissionStats?.total || 0),
+        lastAt: submissionStats?.last_at || null,
+        byStatus: submissionsByStatus,
+      },
+    },
+    recent: {
+      comments: recentComments.map((row) => ({
+        id: row.snowflake_id,
+        slug: row.slug_id,
+        pageTitle: row.title,
+        createdAt: row.created_at,
+        excerpt: buildExcerpt(row.body),
+      })),
+      likes: recentLikes.map((row) => ({
+        id: row.snowflake_id,
+        slug: row.slug_id,
+        pageTitle: row.title,
+        createdAt: row.created_at,
+      })),
+      views: recentViews.map((row) => ({
+        id: row.snowflake_id,
+        slug: row.slug_id,
+        pageTitle: row.title,
+        createdAt: row.viewed_at,
+      })),
+      submissions: recentSubmissions.map((row) => ({
+        id: row.snowflake_id,
+        status: row.status,
+        type: row.type,
+        createdAt: row.created_at,
+        pageTitle: row.current_title || row.title,
+        slug:
+          row.result_slug_id || row.current_slug || row.target_slug_id || null,
+      })),
+    },
+  };
+}
+
+function buildExcerpt(text, limit = 160) {
+  if (!text) {
+    return "";
+  }
+  const normalized = String(text).replace(/\s+/g, " ").trim();
+  if (normalized.length <= limit) {
+    return normalized;
+  }
+  return normalized.slice(0, Math.max(0, limit - 1)).trimEnd() + "…";
+}

--- a/views/ip_profile.ejs
+++ b/views/ip_profile.ejs
@@ -1,0 +1,153 @@
+<% const pageTitle = `Profil IP #${profile.shortHash}`; %>
+<% title = pageTitle; %>
+<section class="card ip-profile-card">
+  <header class="ip-profile-header">
+    <h1 class="mt-0">Profil IP #<%= profile.shortHash %></h1>
+    <p class="text-muted">
+      Ce profil regroupe les activités publiques associées à une adresse IP. L'adresse IP réelle est hachée afin de protéger l'anonymat des contributeurs non connectés.
+    </p>
+    <% if (isOwner) { %>
+      <p class="ip-profile-owner-note">
+        Vous consultez votre propre profil IP. Seules les contributions publiques (commentaires approuvés, likes, vues et propositions) sont visibles ici.
+      </p>
+    <% } %>
+  </header>
+
+  <dl class="ip-profile-details">
+    <div>
+      <dt>Profil créé</dt>
+      <dd><%= profile.createdAt ? new Date(profile.createdAt).toLocaleString('fr-FR') : 'Inconnu' %></dd>
+    </div>
+    <div>
+      <dt>Dernière activité</dt>
+      <dd><%= profile.lastSeenAt ? new Date(profile.lastSeenAt).toLocaleString('fr-FR') : 'Inconnue' %></dd>
+    </div>
+  </dl>
+
+  <ul class="stat-grid ip-profile-stats">
+    <li class="ip-profile-stat">
+      <span class="label">Vues enregistrées</span>
+      <strong><%= profile.stats.views.total %></strong>
+      <span class="stat-sub">Pages distinctes : <strong><%= profile.stats.views.uniquePages %></strong></span>
+      <% if (profile.stats.views.lastAt) { %>
+        <span class="stat-sub">Dernière vue : <%= new Date(profile.stats.views.lastAt).toLocaleString('fr-FR') %></span>
+      <% } %>
+    </li>
+    <li class="ip-profile-stat">
+      <span class="label">Likes</span>
+      <strong><%= profile.stats.likes.total %></strong>
+      <span class="stat-sub">Pages distinctes : <strong><%= profile.stats.likes.uniquePages %></strong></span>
+      <% if (profile.stats.likes.lastAt) { %>
+        <span class="stat-sub">Dernier like : <%= new Date(profile.stats.likes.lastAt).toLocaleString('fr-FR') %></span>
+      <% } %>
+    </li>
+    <li class="ip-profile-stat">
+      <span class="label">Commentaires approuvés</span>
+      <strong><%= profile.stats.comments.total %></strong>
+      <% if (profile.stats.comments.lastAt) { %>
+        <span class="stat-sub">Dernier commentaire : <%= new Date(profile.stats.comments.lastAt).toLocaleString('fr-FR') %></span>
+      <% } else { %>
+        <span class="stat-sub">Aucun commentaire approuvé pour le moment.</span>
+      <% } %>
+    </li>
+    <li class="ip-profile-stat">
+      <span class="label">Propositions</span>
+      <strong><%= profile.stats.submissions.total %></strong>
+      <% const submissionStatuses = profile.stats.submissions.byStatus || {}; %>
+      <% if (Object.keys(submissionStatuses).length) { %>
+        <span class="stat-sub">
+          <% Object.entries(submissionStatuses).forEach(([status, total], index, entries) => { %>
+            <%= status %> : <strong><%= total %></strong><%= index < entries.length - 1 ? ' · ' : '' %>
+          <% }) %>
+        </span>
+      <% } else { %>
+        <span class="stat-sub">Aucune proposition enregistrée.</span>
+      <% } %>
+      <% if (profile.stats.submissions.lastAt) { %>
+        <span class="stat-sub">Dernière proposition : <%= new Date(profile.stats.submissions.lastAt).toLocaleString('fr-FR') %></span>
+      <% } %>
+    </li>
+  </ul>
+
+  <section class="ip-profile-section">
+    <h2>Commentaires récents</h2>
+    <% if (profile.recent.comments.length) { %>
+      <ul class="ip-profile-activity">
+        <% profile.recent.comments.forEach((item) => { %>
+          <li>
+            <div class="ip-profile-activity-meta">
+              <a href="/wiki/<%= item.slug %>#comments"><%= item.pageTitle %></a>
+              <time datetime="<%= item.createdAt %>"><%= new Date(item.createdAt).toLocaleString('fr-FR') %></time>
+            </div>
+            <% if (item.excerpt) { %>
+              <p class="ip-profile-activity-text"><%= item.excerpt %></p>
+            <% } %>
+          </li>
+        <% }) %>
+      </ul>
+    <% } else { %>
+      <p class="text-muted">Aucun commentaire approuvé n'est encore visible.</p>
+    <% } %>
+  </section>
+
+  <section class="ip-profile-section">
+    <h2>Likes récents</h2>
+    <% if (profile.recent.likes.length) { %>
+      <ul class="ip-profile-activity">
+        <% profile.recent.likes.forEach((item) => { %>
+          <li>
+            <div class="ip-profile-activity-meta">
+              <a href="/wiki/<%= item.slug %>"><%= item.pageTitle %></a>
+              <time datetime="<%= item.createdAt %>"><%= new Date(item.createdAt).toLocaleString('fr-FR') %></time>
+            </div>
+          </li>
+        <% }) %>
+      </ul>
+    <% } else { %>
+      <p class="text-muted">Aucun like enregistré pour l'instant.</p>
+    <% } %>
+  </section>
+
+  <section class="ip-profile-section">
+    <h2>Pages consultées récemment</h2>
+    <% if (profile.recent.views.length) { %>
+      <ul class="ip-profile-activity">
+        <% profile.recent.views.forEach((item) => { %>
+          <li>
+            <div class="ip-profile-activity-meta">
+              <a href="/wiki/<%= item.slug %>"><%= item.pageTitle %></a>
+              <time datetime="<%= item.createdAt %>"><%= new Date(item.createdAt).toLocaleString('fr-FR') %></time>
+            </div>
+          </li>
+        <% }) %>
+      </ul>
+    <% } else { %>
+      <p class="text-muted">Aucune vue enregistrée avec cette IP.</p>
+    <% } %>
+  </section>
+
+  <section class="ip-profile-section">
+    <h2>Propositions récentes</h2>
+    <% if (profile.recent.submissions.length) { %>
+      <ul class="ip-profile-activity">
+        <% profile.recent.submissions.forEach((item) => { %>
+          <li>
+            <div class="ip-profile-activity-meta">
+              <% if (item.slug) { %>
+                <a href="/wiki/<%= item.slug %>"><%= item.pageTitle %></a>
+              <% } else { %>
+                <span><%= item.pageTitle || 'Proposition' %></span>
+              <% } %>
+              <time datetime="<%= item.createdAt %>"><%= new Date(item.createdAt).toLocaleString('fr-FR') %></time>
+            </div>
+            <p class="ip-profile-activity-text text-muted">
+              Type : <strong><%= item.type %></strong> · Statut : <strong><%= item.status %></strong>
+            </p>
+          </li>
+        <% }) %>
+      </ul>
+    <% } else { %>
+      <p class="text-muted">Aucune proposition n'a encore été envoyée avec cette IP.</p>
+    <% } %>
+  </section>
+</section>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -42,6 +42,9 @@
     <nav class="vnav" id="vnav">
       <a href="/">🏠 Accueil</a>
       <a href="/rss.xml">📰 Flux RSS</a>
+      <% if (typeof canViewIpProfile !== 'undefined' && canViewIpProfile) { %>
+        <a href="/profiles/ip/me">🪪 Mon profil IP</a>
+      <% } %>
       <% if (!currentUser || !currentUser.is_admin) { %>
         <a href="/new">✍️ Contribuer</a>
       <% } %>

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -68,6 +68,14 @@
           <div class="comment-meta">
             <strong><%= c.author || 'Anonyme' %></strong>
             <span>· <%= new Date(c.created_at).toLocaleString('fr-FR') %></span>
+            <% if (c.ipProfile) { %>
+              <span>
+                ·
+                <a class="comment-ip-profile" href="/profiles/ip/<%= c.ipProfile.hash %>">
+                  Profil IP #<%= c.ipProfile.shortHash %>
+                </a>
+              </span>
+            <% } %>
           </div>
           <div class="comment-body"><%= c.body %></div>
           <% if (ownCommentTokens && ownCommentTokens[c.snowflake_id]) { %>


### PR DESCRIPTION
## Summary
- create a dedicated ip_profiles table and utility helpers to hash IPs and compute activity statistics
- update page routes to record profiles during anonymous activity and expose a public profile view with navigation and comment links
- add styles and layout tweaks for IP profile cards and hashed profile badges in comments

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68da4afd606c8321beebf9a5abbf3a05