### PR TITLE
Add admin ban appeal management view

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -36,6 +36,7 @@ import {
   invalidateSiteSettingsCache,
 } from "../utils/settingsService.js";
 import { pushNotification } from "../utils/notifications.js";
+import { countBanAppeals, fetchBanAppeals } from "../utils/banAppeals.js";
 
 await ensureUploadDir();
 
@@ -213,6 +214,21 @@ async function handleCommentDeletion(req, res) {
 
 r.delete("/comments/:id", handleCommentDeletion);
 r.post("/comments/:id/delete", handleCommentDeletion);
+
+r.get("/ban-appeals", async (req, res) => {
+  const total = await countBanAppeals();
+  const pagination = buildPagination(req, total);
+  const offset = (pagination.page - 1) * pagination.perPage;
+  const appeals = await fetchBanAppeals({
+    limit: pagination.perPage,
+    offset,
+  });
+
+  res.render("admin/banAppeals", {
+    appeals,
+    pagination,
+  });
+});
 
 r.get("/ip-bans", async (req, res) => {
   const activeCountRow = await get(

--- a/utils/banAppeals.js
+++ b/utils/banAppeals.js
@@ -1,4 +1,4 @@
-import { run } from "../db.js";
+import { all, get, run } from "../db.js";
 import { generateSnowflake } from "./snowflake.js";
 
 export async function createBanAppeal({
@@ -19,4 +19,21 @@ export async function createBanAppeal({
     [snowflake, ip || null, scope || null, value || null, reason || null, trimmed],
   );
   return snowflake;
+}
+
+export async function countBanAppeals() {
+  const row = await get("SELECT COUNT(*) AS total FROM ban_appeals");
+  return Number(row?.total ?? 0);
+}
+
+export async function fetchBanAppeals({ limit, offset }) {
+  const perPage = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 20;
+  const start = Number.isFinite(offset) && offset >= 0 ? Math.floor(offset) : 0;
+  return all(
+    `SELECT snowflake_id, ip, scope, value, reason, message, created_at
+       FROM ban_appeals
+      ORDER BY created_at DESC
+      LIMIT ? OFFSET ?`,
+    [perPage, start],
+  );
 }

--- a/views/admin/banAppeals.ejs
+++ b/views/admin/banAppeals.ejs
@@ -1,0 +1,70 @@
+<% title = 'Demandes de déban'; %>
+<h1>Demandes de débannissement</h1>
+
+<section class="card">
+  <h2>Demandes reçues (<%= pagination.totalItems %>)</h2>
+  <% if (!appeals.length) { %>
+    <p>Aucune demande n'a encore été envoyée.</p>
+  <% } else { %>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Date</th>
+            <th>IP</th>
+            <th>Portée</th>
+            <th>Valeur</th>
+            <th>Motif du ban</th>
+            <th>Message de l'appel</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% appeals.forEach(appeal => { %>
+            <tr>
+              <td><code><%= appeal.snowflake_id %></code></td>
+              <td><%= new Date(appeal.created_at).toLocaleString('fr-FR') %></td>
+              <td>
+                <% if (appeal.ip) { %>
+                  <code><%= appeal.ip %></code>
+                <% } else { %>
+                  -
+                <% } %>
+              </td>
+              <td><%= appeal.scope || '-' %></td>
+              <td><%= appeal.value || '-' %></td>
+              <td><%= appeal.reason || '-' %></td>
+              <td>
+                <pre><%= appeal.message %></pre>
+              </td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+    <div class="table-footer">
+      <form method="get">
+        <label for="appeals-per-page" class="nowrap">Éléments par page</label>
+        <select id="appeals-per-page" name="perPage" onchange="this.form.submit()">
+          <% pagination.perPageOptions.forEach(option => { %>
+            <option value="<%= option %>" <%= option === pagination.perPage ? 'selected' : '' %>><%= option %></option>
+          <% }) %>
+        </select>
+        <input type="hidden" name="page" value="1">
+      </form>
+      <span>Page <%= pagination.page %> sur <%= pagination.totalPages %></span>
+      <div class="pager">
+        <% if (pagination.hasPrevious) { %>
+          <a class="btn" data-icon="⬅️" href="?page=<%= pagination.previousPage %>&perPage=<%= pagination.perPage %>">Précédent</a>
+        <% } else { %>
+          <span class="btn" data-icon="⬅️" aria-disabled="true">Précédent</span>
+        <% } %>
+        <% if (pagination.hasNext) { %>
+          <a class="btn" data-icon="➡️" href="?page=<%= pagination.nextPage %>&perPage=<%= pagination.perPage %>">Suivant</a>
+        <% } else { %>
+          <span class="btn" data-icon="➡️" aria-disabled="true">Suivant</span>
+        <% } %>
+      </div>
+    </div>
+  <% } %>
+</section>

--- a/views/banned.ejs
+++ b/views/banned.ejs
@@ -1,4 +1,7 @@
 <% title = 'Accès restreint'; %>
+<% const showAppealSuccess = typeof appealSuccess !== "undefined" && appealSuccess; %>
+<% const appealMessageValue = typeof appealMessage !== "undefined" ? appealMessage : ""; %>
+<% const appealErrorMessage = typeof appealError !== "undefined" ? appealError : null; %>
 <section class="card">
   <h1>Accès restreint</h1>
   <p>
@@ -7,7 +10,7 @@
   <% if (ban && ban.reason) { %>
     <p><strong>Raison :</strong> <%= ban.reason %></p>
   <% } %>
-  <% if (appealSuccess) { %>
+  <% if (showAppealSuccess) { %>
     <p class="alert alert-success">
       Votre demande de débannissement a bien été envoyée. Un administrateur la traitera prochainement.
     </p>
@@ -24,10 +27,10 @@
           rows="5"
           maxlength="2000"
           required
-        ><%= (appealMessage || "") %></textarea>
+        ><%= appealMessageValue %></textarea>
       </div>
-      <% if (appealError) { %>
-        <p class="form-error"><%= appealError %></p>
+      <% if (appealErrorMessage) { %>
+        <p class="form-error"><%= appealErrorMessage %></p>
       <% } %>
       <button type="submit" class="btn btn-primary">Envoyer une demande de déban</button>
     </form>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -57,6 +57,7 @@
         <a href="/admin/comments">💬 Commentaires</a>
         <a href="/admin/likes">❤️ Likes</a>
         <a href="/admin/ip-bans">🚫 Blocages IP</a>
+        <a href="/admin/ban-appeals">📬 Demandes de déban</a>
         <a href="/admin/events">📜 Événements</a>
         <a href="/admin/uploads">🖼️ Images</a>
         <a href="/admin/settings">⚙️ Paramètres</a>


### PR DESCRIPTION
## Summary
- guard the banned page against missing appeal flags so it can render outside the appeal flow
- expose helpers to list ban appeals and add an admin route with a paginated listing
- link the new listing from the admin sidebar with a dedicated ban appeal view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da5319a82c8321b6eab063881ae7bc