### PR TITLE
Add search across admin dashboards

### DIFF
--- a/utils/banAppeals.js
+++ b/utils/banAppeals.js
@@ -21,19 +21,49 @@ export async function createBanAppeal({
   return snowflake;
 }
 
-export async function countBanAppeals() {
-  const row = await get("SELECT COUNT(*) AS total FROM ban_appeals");
+export async function countBanAppeals({ search } = {}) {
+  const filters = [];
+  const params = [];
+
+  if (search) {
+    const like = `%${search}%`;
+    filters.push(
+      "(snowflake_id LIKE ? OR ip LIKE ? OR scope LIKE ? OR value LIKE ? OR reason LIKE ? OR message LIKE ?)",
+    );
+    params.push(like, like, like, like, like, like);
+  }
+
+  const where = filters.length ? `WHERE ${filters.join(" AND ")}` : "";
+  const row = await get(
+    `SELECT COUNT(*) AS total FROM ban_appeals ${where}`,
+    params,
+  );
   return Number(row?.total ?? 0);
 }
 
-export async function fetchBanAppeals({ limit, offset }) {
+export async function fetchBanAppeals({ limit, offset, search } = {}) {
   const perPage = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 20;
   const start = Number.isFinite(offset) && offset >= 0 ? Math.floor(offset) : 0;
+
+  const filters = [];
+  const params = [];
+
+  if (search) {
+    const like = `%${search}%`;
+    filters.push(
+      "(snowflake_id LIKE ? OR ip LIKE ? OR scope LIKE ? OR value LIKE ? OR reason LIKE ? OR message LIKE ?)",
+    );
+    params.push(like, like, like, like, like, like);
+  }
+
+  const where = filters.length ? `WHERE ${filters.join(" AND ")}` : "";
+
   return all(
     `SELECT snowflake_id, ip, scope, value, reason, message, created_at
        FROM ban_appeals
+      ${where}
       ORDER BY created_at DESC
       LIMIT ? OFFSET ?`,
-    [perPage, start],
+    [...params, perPage, start],
   );
 }

--- a/views/admin/banAppeals.ejs
+++ b/views/admin/banAppeals.ejs
@@ -1,6 +1,27 @@
 <% title = 'Demandes de déban'; %>
 <h1>Demandes de débannissement</h1>
 
+<form method="get" class="card mb-md">
+  <div class="flex flex-wrap gap-sm items-end">
+    <label class="stack-form">
+      <span class="text-sm text-muted">Rechercher</span>
+      <input
+        type="text"
+        name="search"
+        value="<%= typeof searchTerm === 'string' ? searchTerm : '' %>"
+        placeholder="ID, IP, message…"
+        class="flex-basis-260"
+      />
+    </label>
+    <input type="hidden" name="page" value="1" />
+    <input type="hidden" name="perPage" value="<%= pagination.perPage %>" />
+    <button class="btn" data-icon="🔍" type="submit">Rechercher</button>
+    <% if (searchTerm) { %>
+      <a class="btn secondary" href="/admin/ban-appeals">Réinitialiser</a>
+    <% } %>
+  </div>
+</form>
+
 <section class="card">
   <h2>Demandes reçues (<%= pagination.totalItems %>)</h2>
   <% if (!appeals.length) { %>
@@ -42,29 +63,6 @@
         </tbody>
       </table>
     </div>
-    <div class="table-footer">
-      <form method="get">
-        <label for="appeals-per-page" class="nowrap">Éléments par page</label>
-        <select id="appeals-per-page" name="perPage" onchange="this.form.submit()">
-          <% pagination.perPageOptions.forEach(option => { %>
-            <option value="<%= option %>" <%= option === pagination.perPage ? 'selected' : '' %>><%= option %></option>
-          <% }) %>
-        </select>
-        <input type="hidden" name="page" value="1">
-      </form>
-      <span>Page <%= pagination.page %> sur <%= pagination.totalPages %></span>
-      <div class="pager">
-        <% if (pagination.hasPrevious) { %>
-          <a class="btn" data-icon="⬅️" href="?page=<%= pagination.previousPage %>&perPage=<%= pagination.perPage %>">Précédent</a>
-        <% } else { %>
-          <span class="btn" data-icon="⬅️" aria-disabled="true">Précédent</span>
-        <% } %>
-        <% if (pagination.hasNext) { %>
-          <a class="btn" data-icon="➡️" href="?page=<%= pagination.nextPage %>&perPage=<%= pagination.perPage %>">Suivant</a>
-        <% } else { %>
-          <span class="btn" data-icon="➡️" aria-disabled="true">Suivant</span>
-        <% } %>
-      </div>
-    </div>
+    <%- include('./paginationControls', { pagination }) %>
   <% } %>
 </section>

--- a/views/admin/comments.ejs
+++ b/views/admin/comments.ejs
@@ -1,5 +1,28 @@
 <h1>Modération des commentaires</h1>
 
+<form method="get" class="card mb-md">
+  <div class="flex flex-wrap gap-sm items-end">
+    <label class="stack-form">
+      <span class="text-sm text-muted">Rechercher</span>
+      <input
+        type="text"
+        name="search"
+        value="<%= typeof searchTerm === 'string' ? searchTerm : '' %>"
+        placeholder="ID, IP, auteur, page…"
+        class="flex-basis-260"
+      />
+    </label>
+    <input type="hidden" name="pendingPage" value="1" />
+    <input type="hidden" name="recentPage" value="1" />
+    <input type="hidden" name="pendingPerPage" value="<%= pendingPagination.perPage %>" />
+    <input type="hidden" name="recentPerPage" value="<%= recentPagination.perPage %>" />
+    <button class="btn" data-icon="🔍" type="submit">Rechercher</button>
+    <% if (searchTerm) { %>
+      <a class="btn secondary" href="/admin/comments">Réinitialiser</a>
+    <% } %>
+  </div>
+</form>
+
 <section class="card mb-xl">
   <h2 class="mt-0">En attente de validation (<%= pendingPagination.totalItems %>)</h2>
   <% if (!pending.length) { %>
@@ -34,32 +57,7 @@
         </li>
       <% }) %>
     </ul>
-    <div class="table-footer">
-      <form method="get">
-        <label for="pending-per-page" class="nowrap">Éléments par page</label>
-        <select id="pending-per-page" name="pendingPerPage" onchange="this.form.submit()">
-          <% pendingPagination.perPageOptions.forEach(option => { %>
-            <option value="<%= option %>" <%= option === pendingPagination.perPage ? 'selected' : '' %>><%= option %></option>
-          <% }) %>
-        </select>
-        <input type="hidden" name="pendingPage" value="1">
-        <input type="hidden" name="recentPage" value="<%= recentPagination.page %>">
-        <input type="hidden" name="recentPerPage" value="<%= recentPagination.perPage %>">
-      </form>
-      <span>Page <%= pendingPagination.page %> sur <%= pendingPagination.totalPages %></span>
-      <div class="pager">
-        <% if (pendingPagination.hasPrevious) { %>
-          <a class="btn" data-icon="⬅️" href="?pendingPage=<%= pendingPagination.previousPage %>&pendingPerPage=<%= pendingPagination.perPage %>&recentPage=<%= recentPagination.page %>&recentPerPage=<%= recentPagination.perPage %>">Précédent</a>
-        <% } else { %>
-          <span class="btn" data-icon="⬅️" aria-disabled="true">Précédent</span>
-        <% } %>
-        <% if (pendingPagination.hasNext) { %>
-          <a class="btn" data-icon="➡️" href="?pendingPage=<%= pendingPagination.nextPage %>&pendingPerPage=<%= pendingPagination.perPage %>&recentPage=<%= recentPagination.page %>&recentPerPage=<%= recentPagination.perPage %>">Suivant</a>
-        <% } else { %>
-          <span class="btn" data-icon="➡️" aria-disabled="true">Suivant</span>
-        <% } %>
-      </div>
-    </div>
+    <%- include('./paginationControls', { pagination: pendingPagination }) %>
   <% } %>
 </section>
 
@@ -91,31 +89,6 @@
         </li>
       <% }) %>
     </ul>
-    <div class="table-footer">
-      <form method="get">
-        <label for="recent-per-page" class="nowrap">Éléments par page</label>
-        <select id="recent-per-page" name="recentPerPage" onchange="this.form.submit()">
-          <% recentPagination.perPageOptions.forEach(option => { %>
-            <option value="<%= option %>" <%= option === recentPagination.perPage ? 'selected' : '' %>><%= option %></option>
-          <% }) %>
-        </select>
-        <input type="hidden" name="recentPage" value="1">
-        <input type="hidden" name="pendingPage" value="<%= pendingPagination.page %>">
-        <input type="hidden" name="pendingPerPage" value="<%= pendingPagination.perPage %>">
-      </form>
-      <span>Page <%= recentPagination.page %> sur <%= recentPagination.totalPages %></span>
-      <div class="pager">
-        <% if (recentPagination.hasPrevious) { %>
-          <a class="btn" data-icon="⬅️" href="?recentPage=<%= recentPagination.previousPage %>&recentPerPage=<%= recentPagination.perPage %>&pendingPage=<%= pendingPagination.page %>&pendingPerPage=<%= pendingPagination.perPage %>">Précédent</a>
-        <% } else { %>
-          <span class="btn" data-icon="⬅️" aria-disabled="true">Précédent</span>
-        <% } %>
-        <% if (recentPagination.hasNext) { %>
-          <a class="btn" data-icon="➡️" href="?recentPage=<%= recentPagination.nextPage %>&recentPerPage=<%= recentPagination.perPage %>&pendingPage=<%= pendingPagination.page %>&pendingPerPage=<%= pendingPagination.perPage %>">Suivant</a>
-        <% } else { %>
-          <span class="btn" data-icon="➡️" aria-disabled="true">Suivant</span>
-        <% } %>
-      </div>
-    </div>
+    <%- include('./paginationControls', { pagination: recentPagination }) %>
   <% } %>
 </section>

--- a/views/admin/events.ejs
+++ b/views/admin/events.ejs
@@ -1,6 +1,27 @@
 <% title = 'Événements'; %>
 <h1>Journal des événements</h1>
 
+<form method="get" class="card mb-md">
+  <div class="flex flex-wrap gap-sm items-end">
+    <label class="stack-form">
+      <span class="text-sm text-muted">Rechercher</span>
+      <input
+        type="text"
+        name="search"
+        value="<%= typeof searchTerm === 'string' ? searchTerm : '' %>"
+        placeholder="ID, canal, utilisateur…"
+        class="flex-basis-260"
+      />
+    </label>
+    <input type="hidden" name="page" value="1" />
+    <input type="hidden" name="perPage" value="<%= pagination.perPage %>" />
+    <button class="btn" data-icon="🔍" type="submit">Rechercher</button>
+    <% if (searchTerm) { %>
+      <a class="btn secondary" href="/admin/events">Réinitialiser</a>
+    <% } %>
+  </div>
+</form>
+
 <section class="card">
   <h2>Derniers événements</h2>
   <% if (!events.length) { %>
@@ -32,29 +53,6 @@
         </tbody>
       </table>
     </div>
-    <div class="table-footer">
-      <form method="get">
-        <label for="events-per-page" class="nowrap">Éléments par page</label>
-        <select id="events-per-page" name="perPage" onchange="this.form.submit()">
-          <% pagination.perPageOptions.forEach(option => { %>
-            <option value="<%= option %>" <%= option === pagination.perPage ? 'selected' : '' %>><%= option %></option>
-          <% }) %>
-        </select>
-        <input type="hidden" name="page" value="1">
-      </form>
-      <span>Page <%= pagination.page %> sur <%= pagination.totalPages %></span>
-      <div class="pager">
-        <% if (pagination.hasPrevious) { %>
-          <a class="btn" data-icon="⬅️" href="?page=<%= pagination.previousPage %>&perPage=<%= pagination.perPage %>">Précédent</a>
-        <% } else { %>
-          <span class="btn" data-icon="⬅️" aria-disabled="true">Précédent</span>
-        <% } %>
-        <% if (pagination.hasNext) { %>
-          <a class="btn" data-icon="➡️" href="?page=<%= pagination.nextPage %>&perPage=<%= pagination.perPage %>">Suivant</a>
-        <% } else { %>
-          <span class="btn" data-icon="➡️" aria-disabled="true">Suivant</span>
-        <% } %>
-      </div>
-    </div>
+    <%- include('./paginationControls', { pagination }) %>
   <% } %>
 </section>

--- a/views/admin/ip_bans.ejs
+++ b/views/admin/ip_bans.ejs
@@ -1,6 +1,29 @@
 <% title = 'Blocages IP'; %>
 <h1>Blocages IP</h1>
 
+<form method="get" class="card mb-md">
+  <div class="flex flex-wrap gap-sm items-end">
+    <label class="stack-form">
+      <span class="text-sm text-muted">Rechercher</span>
+      <input
+        type="text"
+        name="search"
+        value="<%= typeof searchTerm === 'string' ? searchTerm : '' %>"
+        placeholder="ID, IP, motif…"
+        class="flex-basis-260"
+      />
+    </label>
+    <input type="hidden" name="activePage" value="1" />
+    <input type="hidden" name="liftedPage" value="1" />
+    <input type="hidden" name="activePerPage" value="<%= activePagination.perPage %>" />
+    <input type="hidden" name="liftedPerPage" value="<%= liftedPagination.perPage %>" />
+    <button class="btn" data-icon="🔍" type="submit">Rechercher</button>
+    <% if (searchTerm) { %>
+      <a class="btn secondary" href="/admin/ip-bans">Réinitialiser</a>
+    <% } %>
+  </div>
+</form>
+
 <section class="card mb-xl">
   <h2>Ajouter un blocage</h2>
   <form method="post" action="/admin/ip-bans" class="grid grid-auto">
@@ -71,32 +94,7 @@
         </tbody>
       </table>
     </div>
-    <div class="table-footer">
-      <form method="get">
-        <label for="active-per-page" class="nowrap">Éléments par page</label>
-        <select id="active-per-page" name="activePerPage" onchange="this.form.submit()">
-          <% activePagination.perPageOptions.forEach(option => { %>
-            <option value="<%= option %>" <%= option === activePagination.perPage ? 'selected' : '' %>><%= option %></option>
-          <% }) %>
-        </select>
-        <input type="hidden" name="activePage" value="1">
-        <input type="hidden" name="liftedPage" value="<%= liftedPagination.page %>">
-        <input type="hidden" name="liftedPerPage" value="<%= liftedPagination.perPage %>">
-      </form>
-      <span>Page <%= activePagination.page %> sur <%= activePagination.totalPages %></span>
-      <div class="pager">
-        <% if (activePagination.hasPrevious) { %>
-          <a class="btn" data-icon="⬅️" href="?activePage=<%= activePagination.previousPage %>&activePerPage=<%= activePagination.perPage %>&liftedPage=<%= liftedPagination.page %>&liftedPerPage=<%= liftedPagination.perPage %>">Précédent</a>
-        <% } else { %>
-          <span class="btn" data-icon="⬅️" aria-disabled="true">Précédent</span>
-        <% } %>
-        <% if (activePagination.hasNext) { %>
-          <a class="btn" data-icon="➡️" href="?activePage=<%= activePagination.nextPage %>&activePerPage=<%= activePagination.perPage %>&liftedPage=<%= liftedPagination.page %>&liftedPerPage=<%= liftedPagination.perPage %>">Suivant</a>
-        <% } else { %>
-          <span class="btn" data-icon="➡️" aria-disabled="true">Suivant</span>
-        <% } %>
-      </div>
-    </div>
+    <%- include('./paginationControls', { pagination: activePagination }) %>
   <% } %>
 </section>
 
@@ -133,31 +131,6 @@
         </tbody>
       </table>
     </div>
-    <div class="table-footer">
-      <form method="get">
-        <label for="lifted-per-page" class="nowrap">Éléments par page</label>
-        <select id="lifted-per-page" name="liftedPerPage" onchange="this.form.submit()">
-          <% liftedPagination.perPageOptions.forEach(option => { %>
-            <option value="<%= option %>" <%= option === liftedPagination.perPage ? 'selected' : '' %>><%= option %></option>
-          <% }) %>
-        </select>
-        <input type="hidden" name="liftedPage" value="1">
-        <input type="hidden" name="activePage" value="<%= activePagination.page %>">
-        <input type="hidden" name="activePerPage" value="<%= activePagination.perPage %>">
-      </form>
-      <span>Page <%= liftedPagination.page %> sur <%= liftedPagination.totalPages %></span>
-      <div class="pager">
-        <% if (liftedPagination.hasPrevious) { %>
-          <a class="btn" data-icon="⬅️" href="?liftedPage=<%= liftedPagination.previousPage %>&liftedPerPage=<%= liftedPagination.perPage %>&activePage=<%= activePagination.page %>&activePerPage=<%= activePagination.perPage %>">Précédent</a>
-        <% } else { %>
-          <span class="btn" data-icon="⬅️" aria-disabled="true">Précédent</span>
-        <% } %>
-        <% if (liftedPagination.hasNext) { %>
-          <a class="btn" data-icon="➡️" href="?liftedPage=<%= liftedPagination.nextPage %>&liftedPerPage=<%= liftedPagination.perPage %>&activePage=<%= activePagination.page %>&activePerPage=<%= activePagination.perPage %>">Suivant</a>
-        <% } else { %>
-          <span class="btn" data-icon="➡️" aria-disabled="true">Suivant</span>
-        <% } %>
-      </div>
-    </div>
+    <%- include('./paginationControls', { pagination: liftedPagination }) %>
   <% } %>
 </section>

--- a/views/admin/likes.ejs
+++ b/views/admin/likes.ejs
@@ -1,9 +1,26 @@
 <% title='Likes'; %>
 <h1>Likes par IP</h1>
-<div class="card">
-  <div class="table-tools">
-    <input id="likeFilter" type="text" placeholder="Filtrer IP ou titre…" />
+<form method="get" class="card mb-md">
+  <div class="flex flex-wrap gap-sm items-end">
+    <label class="stack-form">
+      <span class="text-sm text-muted">Rechercher</span>
+      <input
+        type="text"
+        name="search"
+        value="<%= typeof searchTerm === 'string' ? searchTerm : '' %>"
+        placeholder="ID, IP, article…"
+        class="flex-basis-260"
+      />
+    </label>
+    <input type="hidden" name="page" value="1" />
+    <input type="hidden" name="perPage" value="<%= pagination.perPage %>" />
+    <button class="btn" data-icon="🔍" type="submit">Rechercher</button>
+    <% if (searchTerm) { %>
+      <a class="btn secondary" href="/admin/likes">Réinitialiser</a>
+    <% } %>
   </div>
+</form>
+<div class="card">
   <% if (!rows.length) { %>
     <p>Aucun like enregistré.</p>
   <% } else { %>
@@ -34,38 +51,5 @@
       </table>
     </div>
   <% } %>
-  <div class="table-footer">
-    <form method="get">
-      <label for="likes-per-page" class="nowrap">Éléments par page</label>
-      <select id="likes-per-page" name="perPage" onchange="this.form.submit()">
-        <% pagination.perPageOptions.forEach(option => { %>
-          <option value="<%= option %>" <%= option === pagination.perPage ? 'selected' : '' %>><%= option %></option>
-        <% }) %>
-      </select>
-      <input type="hidden" name="page" value="1">
-    </form>
-    <span>Page <%= pagination.page %> sur <%= pagination.totalPages %></span>
-    <div class="pager">
-      <% if (pagination.hasPrevious) { %>
-        <a class="btn" data-icon="⬅️" href="?page=<%= pagination.previousPage %>&perPage=<%= pagination.perPage %>">Précédent</a>
-      <% } else { %>
-        <span class="btn" data-icon="⬅️" aria-disabled="true">Précédent</span>
-      <% } %>
-      <% if (pagination.hasNext) { %>
-        <a class="btn" data-icon="➡️" href="?page=<%= pagination.nextPage %>&perPage=<%= pagination.perPage %>">Suivant</a>
-      <% } else { %>
-        <span class="btn" data-icon="➡️" aria-disabled="true">Suivant</span>
-      <% } %>
-    </div>
-  </div>
+  <%- include('./paginationControls', { pagination }) %>
 </div>
-<script>
-document.getElementById('likeFilter').addEventListener('input', function(){
-  const q = this.value.toLowerCase();
-  const rows = document.querySelectorAll('#likesTable tbody tr');
-  rows.forEach(tr => {
-    const txt = tr.innerText.toLowerCase();
-    tr.style.display = txt.includes(q) ? '' : 'none';
-  });
-});
-</script>

--- a/views/admin/submissions.ejs
+++ b/views/admin/submissions.ejs
@@ -1,6 +1,29 @@
 <% title = 'Contributions'; %>
 <h1>Contributions des visiteurs</h1>
 
+<form method="get" class="card mb-md">
+  <div class="flex flex-wrap gap-sm items-end">
+    <label class="stack-form">
+      <span class="text-sm text-muted">Rechercher</span>
+      <input
+        type="text"
+        name="search"
+        value="<%= typeof searchTerm === 'string' ? searchTerm : '' %>"
+        placeholder="ID, IP, titre, page…"
+        class="flex-basis-260"
+      />
+    </label>
+    <input type="hidden" name="pendingPage" value="1" />
+    <input type="hidden" name="recentPage" value="1" />
+    <input type="hidden" name="pendingPerPage" value="<%= pendingPagination.perPage %>" />
+    <input type="hidden" name="recentPerPage" value="<%= recentPagination.perPage %>" />
+    <button class="btn" data-icon="🔍" type="submit">Rechercher</button>
+    <% if (searchTerm) { %>
+      <a class="btn secondary" href="/admin/submissions">Réinitialiser</a>
+    <% } %>
+  </div>
+</form>
+
 <section class="card mb-xl">
   <h2>En attente (<%= pendingPagination.totalItems %>)</h2>
   <% if (!pending.length) { %>

--- a/views/admin/uploads.ejs
+++ b/views/admin/uploads.ejs
@@ -20,6 +20,27 @@
   <div id="uploadMessage" class="mt-sm"></div>
 </div>
 
+<form method="get" class="card mb-md">
+  <div class="flex flex-wrap gap-sm items-end">
+    <label class="stack-form">
+      <span class="text-sm text-muted">Rechercher</span>
+      <input
+        type="text"
+        name="search"
+        value="<%= typeof searchTerm === 'string' ? searchTerm : '' %>"
+        placeholder="UUID, nom de fichier…"
+        class="flex-basis-260"
+      />
+    </label>
+    <input type="hidden" name="page" value="1" />
+    <input type="hidden" name="perPage" value="<%= pagination.perPage %>" />
+    <button class="btn" data-icon="🔍" type="submit">Rechercher</button>
+    <% if (searchTerm) { %>
+      <a class="btn secondary" href="/admin/uploads">Réinitialiser</a>
+    <% } %>
+  </div>
+</form>
+
 <% if (uploads.length) { %>
   <div class="table-wrap">
     <table class="data-table" id="uploadsTable">
@@ -67,30 +88,7 @@
       </tbody>
     </table>
   </div>
-  <div class="table-footer">
-    <form method="get">
-      <label for="uploads-per-page" class="nowrap">Éléments par page</label>
-      <select id="uploads-per-page" name="perPage" onchange="this.form.submit()">
-        <% pagination.perPageOptions.forEach(option => { %>
-          <option value="<%= option %>" <%= option === pagination.perPage ? 'selected' : '' %>><%= option %></option>
-        <% }) %>
-      </select>
-      <input type="hidden" name="page" value="1">
-    </form>
-    <span>Page <%= pagination.page %> sur <%= pagination.totalPages %></span>
-    <div class="pager">
-      <% if (pagination.hasPrevious) { %>
-        <a class="btn" data-icon="⬅️" href="?page=<%= pagination.previousPage %>&perPage=<%= pagination.perPage %>">Précédent</a>
-      <% } else { %>
-        <span class="btn" data-icon="⬅️" aria-disabled="true">Précédent</span>
-      <% } %>
-      <% if (pagination.hasNext) { %>
-        <a class="btn" data-icon="➡️" href="?page=<%= pagination.nextPage %>&perPage=<%= pagination.perPage %>">Suivant</a>
-      <% } else { %>
-        <span class="btn" data-icon="➡️" aria-disabled="true">Suivant</span>
-      <% } %>
-    </div>
-  </div>
+  <%- include('./paginationControls', { pagination }) %>
 <% } else { %>
   <p class="card text-muted">Aucune image disponible pour le moment.</p>
 <% } %>

--- a/views/admin/users.ejs
+++ b/views/admin/users.ejs
@@ -1,5 +1,25 @@
 <% title='Utilisateurs'; %>
 <h1>Utilisateurs (admins uniquement)</h1>
+<form method="get" class="card mb-md">
+  <div class="flex flex-wrap gap-sm items-end">
+    <label class="stack-form">
+      <span class="text-sm text-muted">Rechercher</span>
+      <input
+        type="text"
+        name="search"
+        value="<%= typeof searchTerm === 'string' ? searchTerm : '' %>"
+        placeholder="ID, nom, pseudo…"
+        class="flex-basis-260"
+      />
+    </label>
+    <input type="hidden" name="page" value="1" />
+    <input type="hidden" name="perPage" value="<%= pagination.perPage %>" />
+    <button class="btn" data-icon="🔍" type="submit">Rechercher</button>
+    <% if (searchTerm) { %>
+      <a class="btn secondary" href="/admin/users">Réinitialiser</a>
+    <% } %>
+  </div>
+</form>
 <form method="post" class="card">
   <div class="flex flex-wrap gap-sm">
     <input type="text" name="username" placeholder="nouvel admin" required />
@@ -43,28 +63,5 @@
       </tbody>
     </table>
   </div>
-  <div class="table-footer">
-    <form method="get">
-      <label for="users-per-page" class="nowrap">Éléments par page</label>
-      <select id="users-per-page" name="perPage" onchange="this.form.submit()">
-        <% pagination.perPageOptions.forEach(option => { %>
-          <option value="<%= option %>" <%= option === pagination.perPage ? 'selected' : '' %>><%= option %></option>
-        <% }) %>
-      </select>
-      <input type="hidden" name="page" value="1">
-    </form>
-    <span>Page <%= pagination.page %> sur <%= pagination.totalPages %></span>
-    <div class="pager">
-      <% if (pagination.hasPrevious) { %>
-        <a class="btn" data-icon="⬅️" href="?page=<%= pagination.previousPage %>&perPage=<%= pagination.perPage %>">Précédent</a>
-      <% } else { %>
-        <span class="btn" data-icon="⬅️" aria-disabled="true">Précédent</span>
-      <% } %>
-      <% if (pagination.hasNext) { %>
-        <a class="btn" data-icon="➡️" href="?page=<%= pagination.nextPage %>&perPage=<%= pagination.perPage %>">Suivant</a>
-      <% } else { %>
-        <span class="btn" data-icon="➡️" aria-disabled="true">Suivant</span>
-      <% } %>
-    </div>
-  </div>
+  <%- include('./paginationControls', { pagination }) %>
 <% } %>


### PR DESCRIPTION
## Summary
- add query-aware filtering to admin routes so ID/IP searches narrow comments, appeals, bans, submissions, uploads, users, likes, and events
- expose matching search fields across admin templates and reuse the shared pagination controls to keep filters across pages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da58fd44108321a2ec5deb96acdb9f