### PR TITLE
Add admin badges, IP profile listing, and changelog page

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ import searchRoutes from "./routes/search.js";
 import { getSiteSettings } from "./utils/settingsService.js";
 import { consumeNotifications } from "./utils/notifications.js";
 import { getClientIp } from "./utils/ip.js";
+import { getAdminActionCounts } from "./utils/adminTasks.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -45,6 +46,14 @@ app.use(async (req, res, next) => {
     res.locals.footerText = settings.footerText;
     res.locals.notifications = consumeNotifications(req);
     res.locals.canViewIpProfile = Boolean(getClientIp(req));
+    if (res.locals.user?.is_admin) {
+      try {
+        res.locals.adminActionCounts = await getAdminActionCounts();
+      } catch (actionErr) {
+        console.error("Unable to load admin action counts", actionErr);
+        res.locals.adminActionCounts = { pendingComments: 0, pendingSubmissions: 0 };
+      }
+    }
     next();
   } catch (err) {
     next(err);

--- a/db.js
+++ b/db.js
@@ -172,6 +172,7 @@ export async function initDb() {
   await ensureColumn("comments", "ip", "TEXT");
   await ensureColumn("comments", "updated_at", "DATETIME");
   await ensureColumn("comments", "edit_token", "TEXT");
+  await ensureColumn("comments", "author_is_admin", "INTEGER NOT NULL DEFAULT 0");
   await ensureColumn("users", "display_name", "TEXT");
   await ensureSnowflake("settings");
   await ensureSnowflake("users");

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -1,0 +1,13 @@
+[
+  {
+    "date": "2024-06-07",
+    "title": "Améliorations de modération et nouveautés interface",
+    "details": [
+      "Ajout d'un panneau des profils IP pour les administrateurs avec recherche et statistiques détaillées.",
+      "Affichage de badges dynamiques dans la navigation admin lorsque des commentaires ou propositions attendent une action.",
+      "Mise en avant visuelle des commentaires rédigés par un administrateur avec effet arc-en-ciel sur le pseudo.",
+      "Création d'une page Changelog accessible depuis la navigation principale pour suivre les évolutions.",
+      "Refonte de la page 404 avec suggestions d'actions pour retrouver son chemin."
+    ]
+  }
+]

--- a/public/style.css
+++ b/public/style.css
@@ -469,6 +469,40 @@ body {
   color: #fff !important;
   text-decoration: none !important;
 }
+.vnav .nav-link--with-badge {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.nav-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  padding: 0.1rem 0.55rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #ff6584, #fbb13c, #53dd6c);
+  color: #0b1020;
+  font-size: 0.85rem;
+  font-weight: 700;
+  box-shadow: 0 0 12px rgba(255, 101, 132, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  animation: nav-badge-pulse 3.5s ease-in-out infinite;
+}
+
+@keyframes nav-badge-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 12px rgba(255, 101, 132, 0.35);
+  }
+  50% {
+    transform: scale(1.08);
+    box-shadow: 0 0 16px rgba(83, 221, 108, 0.55);
+  }
+}
 .vnav a:hover {
   background: #2a3150;
 }
@@ -870,6 +904,145 @@ form .actions {
   align-items: baseline;
   color: var(--muted);
   margin-bottom: 8px;
+}
+
+.comment-author {
+  font-weight: 700;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.comment-author--admin {
+  background-image: linear-gradient(
+    120deg,
+    #ff6b6b,
+    #feca57,
+    #54a0ff,
+    #5f27cd,
+    #ff6b6b
+  );
+  background-size: 360% 360%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 0 0 12px rgba(84, 160, 255, 0.4);
+  animation: rainbow-text 8s linear infinite;
+}
+
+.comment-author-badge {
+  font-size: 0.85rem;
+  color: #ffd166 !important;
+  filter: drop-shadow(0 0 6px rgba(255, 209, 102, 0.7));
+}
+
+@keyframes rainbow-text {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 360% 50%;
+  }
+}
+
+.changelog-card {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.changelog-header h1 {
+  font-size: 2rem;
+}
+
+.changelog-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.changelog-entry {
+  position: relative;
+  padding: 18px 22px 18px 26px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(17, 23, 38, 0.55);
+  box-shadow: 0 14px 34px rgba(10, 14, 28, 0.35);
+}
+
+.changelog-entry::before {
+  content: "";
+  position: absolute;
+  left: 12px;
+  top: 22px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #53dd6c, #54a0ff);
+  box-shadow: 0 0 10px rgba(83, 221, 108, 0.65);
+}
+
+.changelog-entry-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.changelog-entry-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.changelog-entry-header time {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.changelog-entry ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.not-found-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 24px;
+  text-align: left;
+  padding: 40px 36px;
+}
+
+.not-found-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.not-found-code {
+  font-size: 4rem;
+  font-weight: 800;
+  letter-spacing: 6px;
+  color: transparent;
+  background-image: linear-gradient(120deg, #54a0ff, #53dd6c, #feca57);
+  background-clip: text;
+  -webkit-background-clip: text;
+  text-shadow: 0 18px 32px rgba(10, 20, 40, 0.5);
+}
+
+.not-found-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .comment-meta .comment-ip-profile {

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -47,6 +47,7 @@ import {
   decoratePagination,
 } from "../utils/pagination.js";
 import { createBanAppeal } from "../utils/banAppeals.js";
+import { loadChangelogEntries } from "../utils/changelog.js";
 
 const r = Router();
 
@@ -102,6 +103,14 @@ r.get(
       size,
       sizeOptions: PAGE_SIZE_OPTIONS,
     });
+  }),
+);
+
+r.get(
+  "/changelog",
+  asyncHandler(async (_req, res) => {
+    const entries = await loadChangelogEntries();
+    res.render("changelog", { entries });
   }),
 );
 
@@ -382,7 +391,15 @@ r.post(
     const token = randomUUID();
     const commentSnowflake = generateSnowflake();
     const insertResult = await run(
-      "INSERT INTO comments(snowflake_id, page_id, author, body, ip, edit_token) VALUES(?,?,?,?,?,?)",
+      `INSERT INTO comments(
+         snowflake_id,
+         page_id,
+         author,
+         body,
+         ip,
+         edit_token,
+         author_is_admin
+       ) VALUES(?,?,?,?,?,?,?)`,
       [
         commentSnowflake,
         page.id,
@@ -390,6 +407,7 @@ r.post(
         validation.body,
         ip || null,
         token,
+        req.session.user?.is_admin ? 1 : 0,
       ],
     );
 

--- a/utils/adminTasks.js
+++ b/utils/adminTasks.js
@@ -1,0 +1,14 @@
+import { get } from "../db.js";
+import { countPageSubmissions } from "./pageSubmissionService.js";
+
+export async function getAdminActionCounts() {
+  const [pendingCommentsRow, pendingSubmissions] = await Promise.all([
+    get("SELECT COUNT(*) AS total FROM comments WHERE status='pending'"),
+    countPageSubmissions({ status: "pending" }),
+  ]);
+
+  return {
+    pendingComments: Number(pendingCommentsRow?.total ?? 0),
+    pendingSubmissions: Number(pendingSubmissions ?? 0),
+  };
+}

--- a/utils/changelog.js
+++ b/utils/changelog.js
@@ -1,0 +1,59 @@
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const CHANGELOG_PATH = path.join(__dirname, "..", "docs", "changelog.json");
+
+let cachedEntries = null;
+let cachedMtimeMs = 0;
+
+function normalizeEntries(entries) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return entries
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return null;
+      }
+      const title = typeof entry.title === "string" ? entry.title.trim() : "";
+      const description = Array.isArray(entry.details)
+        ? entry.details.filter((line) => typeof line === "string" && line.trim())
+        : [];
+      const date = typeof entry.date === "string" ? entry.date : null;
+      return {
+        title: title || "Mise à jour",
+        date,
+        details: description,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => {
+      const dateA = a.date ? Date.parse(a.date) : 0;
+      const dateB = b.date ? Date.parse(b.date) : 0;
+      return dateB - dateA;
+    });
+}
+
+export async function loadChangelogEntries() {
+  try {
+    const stats = await fs.stat(CHANGELOG_PATH);
+    if (cachedEntries && cachedMtimeMs === stats.mtimeMs) {
+      return cachedEntries;
+    }
+    const raw = await fs.readFile(CHANGELOG_PATH, "utf8");
+    const parsed = JSON.parse(raw);
+    cachedEntries = normalizeEntries(parsed);
+    cachedMtimeMs = stats.mtimeMs;
+    return cachedEntries;
+  } catch (err) {
+    if (err?.code !== "ENOENT") {
+      console.error("Unable to load changelog", err);
+    }
+    cachedEntries = [];
+    cachedMtimeMs = 0;
+    return [];
+  }
+}

--- a/utils/pageService.js
+++ b/utils/pageService.js
@@ -103,6 +103,7 @@ export async function fetchPageComments(pageId, options = {}) {
             c.created_at,
             c.updated_at,
             c.ip AS raw_ip,
+            c.author_is_admin,
             ipr.hash AS ip_hash
        FROM comments c
        LEFT JOIN ip_profiles ipr ON ipr.ip = c.ip
@@ -128,9 +129,15 @@ export async function fetchPageComments(pageId, options = {}) {
   const rows = await all(query, params);
   return rows.map((row) => {
     const ipHash = row.ip_hash || hashIp(row.raw_ip || "");
-    const { raw_ip: _unusedIp, ip_hash: _unusedHash, ...rest } = row;
+    const {
+      raw_ip: _unusedIp,
+      ip_hash: _unusedHash,
+      author_is_admin: _unusedAuthorIsAdmin,
+      ...rest
+    } = row;
     return {
       ...rest,
+      isAdminAuthor: Boolean(row.author_is_admin),
       ipProfile: ipHash
         ? {
             hash: ipHash,

--- a/views/admin/ip_profiles.ejs
+++ b/views/admin/ip_profiles.ejs
@@ -1,0 +1,86 @@
+<% title = 'Profils IP'; %>
+<h1>Profils IP</h1>
+
+<form method="get" class="card mb-md">
+  <div class="flex flex-wrap gap-sm items-end">
+    <label class="stack-form">
+      <span class="text-sm text-muted">Rechercher</span>
+      <input
+        type="text"
+        name="search"
+        value="<%= typeof searchTerm === 'string' ? searchTerm : '' %>"
+        placeholder="Hash, IP…"
+        class="flex-basis-260"
+      />
+    </label>
+    <input type="hidden" name="page" value="1" />
+    <input type="hidden" name="perPage" value="<%= pagination.perPage %>" />
+    <button class="btn" data-icon="🔍" type="submit">Rechercher</button>
+    <% if (searchTerm) { %>
+      <a class="btn secondary" href="/admin/ip-profiles">Réinitialiser</a>
+    <% } %>
+  </div>
+</form>
+
+<section class="card">
+  <h2 class="mt-0">Profils enregistrés (<%= pagination.totalItems %>)</h2>
+  <% if (!profiles.length) { %>
+    <p class="text-muted">Aucun profil IP n'a encore été généré.</p>
+  <% } else { %>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Profil</th>
+            <th>Adresse IP</th>
+            <th>Dernière activité</th>
+            <th>Commentaires</th>
+            <th>Propositions</th>
+            <th>Likes</th>
+            <th>Vues</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% profiles.forEach(profile => { %>
+            <tr>
+              <td>
+                <strong>
+                  <a href="/profiles/ip/<%= profile.hash %>" target="_blank" rel="noopener">
+                    Profil #<%= profile.shortHash %>
+                  </a>
+                </strong>
+                <br />
+                <small class="text-muted">
+                  Créé : <%= profile.createdAt ? new Date(profile.createdAt).toLocaleString('fr-FR') : 'Inconnu' %>
+                </small>
+              </td>
+              <td><code><%= profile.ip %></code></td>
+              <td>
+                <% if (profile.lastSeenAt) { %>
+                  <time datetime="<%= profile.lastSeenAt %>"><%= new Date(profile.lastSeenAt).toLocaleString('fr-FR') %></time>
+                <% } else { %>
+                  <span class="text-muted">Jamais</span>
+                <% } %>
+              </td>
+              <td>
+                <strong><%= profile.stats.approvedComments %></strong>
+                <br />
+                <small class="text-muted">approuvés</small>
+              </td>
+              <td>
+                <strong><%= profile.stats.submissions %></strong>
+              </td>
+              <td>
+                <strong><%= profile.stats.likes %></strong>
+              </td>
+              <td>
+                <strong><%= profile.stats.views %></strong>
+              </td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+    <%- include('./paginationControls', { pagination }) %>
+  <% } %>
+</section>

--- a/views/changelog.ejs
+++ b/views/changelog.ejs
@@ -1,0 +1,35 @@
+<% title = 'Changelog'; %>
+<section class="card changelog-card">
+  <header class="changelog-header">
+    <h1 class="mt-0">Journal des changements</h1>
+    <p class="text-muted">
+      Découvrez l'historique des fonctionnalités et améliorations déployées sur le wiki.
+    </p>
+  </header>
+
+  <% if (!entries || !entries.length) { %>
+    <p class="text-muted">Aucun changement n'a encore été consigné.</p>
+  <% } else { %>
+    <ol class="changelog-list">
+      <% entries.forEach(entry => { %>
+        <li class="changelog-entry">
+          <div class="changelog-entry-header">
+            <h2><%= entry.title %></h2>
+            <% if (entry.date) { %>
+              <time datetime="<%= entry.date %>">
+                <%= new Date(entry.date).toLocaleDateString('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' }) %>
+              </time>
+            <% } %>
+          </div>
+          <% if (entry.details && entry.details.length) { %>
+            <ul>
+              <% entry.details.forEach(detail => { %>
+                <li><%= detail %></li>
+              <% }) %>
+            </ul>
+          <% } %>
+        </li>
+      <% }) %>
+    </ol>
+  <% } %>
+</section>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -42,6 +42,7 @@
     <nav class="vnav" id="vnav">
       <a href="/">🏠 Accueil</a>
       <a href="/rss.xml">📰 Flux RSS</a>
+      <a href="/changelog">🛠️ Changelog</a>
       <% if (typeof canViewIpProfile !== 'undefined' && canViewIpProfile) { %>
         <a href="/profiles/ip/me">🪪 Mon profil IP</a>
       <% } %>
@@ -49,14 +50,26 @@
         <a href="/new">✍️ Contribuer</a>
       <% } %>
       <% if (currentUser && currentUser.is_admin) { %>
+        <% const adminCounts = typeof adminActionCounts !== 'undefined' ? adminActionCounts : {}; %>
         <a href="/new">➕ Nouvelle page</a>
-        <a href="/admin/submissions">📝 Contributions</a>
+        <a href="/admin/submissions" class="nav-link nav-link--with-badge">
+          <span>📝 Contributions</span>
+          <% if (adminCounts.pendingSubmissions) { %>
+            <span class="nav-badge" aria-label="Propositions à examiner"><%= adminCounts.pendingSubmissions %></span>
+          <% } %>
+        </a>
         <a href="/admin/pages">📄 Articles</a>
         <a href="/admin/stats">📈 Statistiques</a>
         <a href="/admin/users">👤 Utilisateurs</a>
-        <a href="/admin/comments">💬 Commentaires</a>
+        <a href="/admin/comments" class="nav-link nav-link--with-badge">
+          <span>💬 Commentaires</span>
+          <% if (adminCounts.pendingComments) { %>
+            <span class="nav-badge" aria-label="Commentaires en attente"><%= adminCounts.pendingComments %></span>
+          <% } %>
+        </a>
         <a href="/admin/likes">❤️ Likes</a>
         <a href="/admin/ip-bans">🚫 Blocages IP</a>
+        <a href="/admin/ip-profiles">🧾 Profils IP</a>
         <a href="/admin/ban-appeals">📬 Demandes de déban</a>
         <a href="/admin/events">📜 Événements</a>
         <a href="/admin/uploads">🖼️ Images</a>

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -66,7 +66,14 @@
       <% comments.forEach(c => { %>
         <li class="comment">
           <div class="comment-meta">
-            <strong><%= c.author || 'Anonyme' %></strong>
+            <% const authorClasses = ['comment-author']; %>
+            <% if (c.isAdminAuthor) { authorClasses.push('comment-author--admin'); } %>
+            <strong class="<%= authorClasses.join(' ') %>">
+              <%= c.author || 'Anonyme' %>
+              <% if (c.isAdminAuthor) { %>
+                <span class="comment-author-badge" title="Administrateur">⭐</span>
+              <% } %>
+            </strong>
             <span>· <%= new Date(c.created_at).toLocaleString('fr-FR') %></span>
             <% if (c.ipProfile) { %>
               <span>

--- a/views/page404.ejs
+++ b/views/page404.ejs
@@ -1,1 +1,15 @@
-<h1>404</h1><div class='card'>Page introuvable.</div>
+<% title = 'Page introuvable'; %>
+<section class="card not-found-card">
+  <div class="not-found-hero">
+    <span class="not-found-code">404</span>
+    <h1>Page introuvable</h1>
+    <p class="text-muted">
+      Désolé, nous n'avons trouvé aucun contenu à cette adresse. La page a peut-être été renommée ou supprimée.
+    </p>
+  </div>
+  <div class="not-found-actions">
+    <a class="btn" data-icon="🏠" href="/">Retour à l'accueil</a>
+    <a class="btn secondary" data-icon="🔍" href="/search">Rechercher une page</a>
+    <a class="btn" data-icon="✍️" href="/new">Créer un article</a>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- highlight moderator workload with admin navigation badges fed by real-time pending counts
- add an IP profile administration table with search, pagination, and rich statistics
- surface a public changelog and refresh UI elements including admin comment flair and the 404 page

## Testing
- node --check app.js

------
https://chatgpt.com/codex/tasks/task_e_68da5e09b8f88321b8b9b592826437c9