### PR TITLE
Add VPN detection and admin IP security dashboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,7 +51,11 @@ app.use(async (req, res, next) => {
         res.locals.adminActionCounts = await getAdminActionCounts();
       } catch (actionErr) {
         console.error("Unable to load admin action counts", actionErr);
-        res.locals.adminActionCounts = { pendingComments: 0, pendingSubmissions: 0 };
+        res.locals.adminActionCounts = {
+          pendingComments: 0,
+          pendingSubmissions: 0,
+          flaggedIps: 0,
+        };
       }
     }
     next();

--- a/db.js
+++ b/db.js
@@ -174,6 +174,14 @@ export async function initDb() {
   await ensureColumn("comments", "edit_token", "TEXT");
   await ensureColumn("comments", "author_is_admin", "INTEGER NOT NULL DEFAULT 0");
   await ensureColumn("users", "display_name", "TEXT");
+  await ensureColumn("ip_profiles", "reputation_status", "TEXT NOT NULL DEFAULT 'unknown'");
+  await ensureColumn("ip_profiles", "reputation_provider", "TEXT");
+  await ensureColumn("ip_profiles", "reputation_reason", "TEXT");
+  await ensureColumn("ip_profiles", "reputation_payload", "TEXT");
+  await ensureColumn("ip_profiles", "reputation_checked_at", "DATETIME");
+  await ensureColumn("ip_profiles", "reputation_flagged_at", "DATETIME");
+  await ensureColumn("ip_profiles", "reputation_reviewed_at", "DATETIME");
+  await ensureColumn("ip_profiles", "reputation_reviewed_by", "TEXT");
   await ensureSnowflake("settings");
   await ensureSnowflake("users");
   await ensureSnowflake("pages");

--- a/public/style.css
+++ b/public/style.css
@@ -160,9 +160,42 @@ body {
   background-color: #e6ffed;
   color: #065f46;
 }
+.alert-warning {
+  background-color: #fff8e6;
+  color: #92400e;
+}
 .alert-error {
   background-color: #ffe5e5;
   color: #a60000;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background-color: #e2e8f0;
+  color: #1e293b;
+}
+
+.status-badge.status-flagged {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.status-badge.status-safe {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.status-badge.status-unknown {
+  background-color: #e2e8f0;
+  color: #334155;
 }
 
 .card.card-highlight {

--- a/utils/adminTasks.js
+++ b/utils/adminTasks.js
@@ -1,14 +1,17 @@
 import { get } from "../db.js";
 import { countPageSubmissions } from "./pageSubmissionService.js";
+import { countFlaggedIpProfiles } from "./ipProfiles.js";
 
 export async function getAdminActionCounts() {
-  const [pendingCommentsRow, pendingSubmissions] = await Promise.all([
+  const [pendingCommentsRow, pendingSubmissions, flaggedIps] = await Promise.all([
     get("SELECT COUNT(*) AS total FROM comments WHERE status='pending'"),
     countPageSubmissions({ status: "pending" }),
+    countFlaggedIpProfiles(),
   ]);
 
   return {
     pendingComments: Number(pendingCommentsRow?.total ?? 0),
     pendingSubmissions: Number(pendingSubmissions ?? 0),
+    flaggedIps: Number(flaggedIps ?? 0),
   };
 }

--- a/utils/ipReputation.js
+++ b/utils/ipReputation.js
@@ -1,0 +1,214 @@
+import fetch from "node-fetch";
+import { get, run } from "../db.js";
+
+const REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 heures
+const MANUAL_OVERRIDE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 jours
+const PROVIDER_NAME = "ip-api.com";
+const PRIVATE_IP_PATTERNS = [
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^172\.(1[6-9]|2\d|3[0-1])\./,
+  /^::1$/,
+  /^fc00:/i,
+  /^fd00:/i,
+  /^fe80:/i,
+  /^::ffff:127\./,
+];
+
+function normalizeIp(ip) {
+  if (typeof ip !== "string") {
+    return "";
+  }
+  return ip.trim();
+}
+
+function parseDate(value) {
+  if (!value) return 0;
+  const ts = Date.parse(value);
+  return Number.isNaN(ts) ? 0 : ts;
+}
+
+function isPrivateIp(ip) {
+  return PRIVATE_IP_PATTERNS.some((pattern) => pattern.test(ip));
+}
+
+async function loadProfile(ip) {
+  return get(
+    `SELECT id, reputation_status, reputation_checked_at, reputation_flagged_at,
+            reputation_reviewed_at, reputation_reviewed_by
+       FROM ip_profiles
+      WHERE ip = ?`,
+    [ip],
+  );
+}
+
+async function performLookup(ip) {
+  const url = `http://ip-api.com/json/${encodeURIComponent(
+    ip,
+  )}?fields=status,message,query,isp,org,as,proxy,hosting,mobile`;
+  const response = await fetch(url, {
+    headers: { "user-agent": "simple-wiki-ip-reputation" },
+  });
+  if (!response.ok) {
+    throw new Error(`Réponse ${response.status}`);
+  }
+  return response.json();
+}
+
+function evaluateLookupResult(result) {
+  if (!result || result.status !== "success") {
+    return {
+      status: "unknown",
+      reason: result?.message || "Impossible d'obtenir des informations.",
+      payload: result || null,
+    };
+  }
+
+  const reasons = [];
+  if (result.proxy) {
+    reasons.push("Signalement proxy/VPN");
+  }
+  if (result.hosting) {
+    reasons.push("Adresse appartenant à un hébergeur");
+  }
+  if (result.mobile) {
+    reasons.push("Connexion mobile");
+  }
+
+  if (reasons.length) {
+    return {
+      status: "flagged",
+      reason: reasons.join(" · "),
+      payload: result,
+    };
+  }
+
+  return {
+    status: "safe",
+    reason: "Aucune activité suspecte détectée par la vérification automatique.",
+    payload: result,
+  };
+}
+
+async function refreshIpReputation(ip, { force = false } = {}) {
+  const normalized = normalizeIp(ip);
+  if (!normalized) {
+    return null;
+  }
+
+  const profile = await loadProfile(normalized);
+  if (!profile?.id) {
+    return null;
+  }
+
+  if (isPrivateIp(normalized)) {
+    const checkedAt = new Date().toISOString();
+    await run(
+      `UPDATE ip_profiles
+          SET reputation_status='safe',
+              reputation_provider='local',
+              reputation_reason='Adresse privée ou locale : vérification ignorée.',
+              reputation_payload=NULL,
+              reputation_checked_at=?,
+              reputation_flagged_at=NULL
+        WHERE id=?`,
+      [checkedAt, profile.id],
+    );
+    return {
+      id: profile.id,
+      ip: normalized,
+      status: "safe",
+      reason: "Adresse privée ou locale : vérification ignorée.",
+      provider: "local",
+      checkedAt,
+      flaggedAt: null,
+    };
+  }
+
+  if (!force) {
+    const lastChecked = parseDate(profile.reputation_checked_at);
+    if (lastChecked && Date.now() - lastChecked < REFRESH_INTERVAL_MS) {
+      return null;
+    }
+
+    if (profile.reputation_status === "safe" && profile.reputation_reviewed_at) {
+      const lastReview = parseDate(profile.reputation_reviewed_at);
+      if (lastReview && Date.now() - lastReview < MANUAL_OVERRIDE_TTL_MS) {
+        return null;
+      }
+    }
+  }
+
+  let lookupResult = null;
+  let evaluation = {
+    status: profile.reputation_status || "unknown",
+    reason: profile.reputation_status ? profile.reputation_status : "",
+    payload: null,
+  };
+
+  try {
+    lookupResult = await performLookup(normalized);
+    evaluation = evaluateLookupResult(lookupResult);
+  } catch (err) {
+    evaluation = {
+      status: profile.reputation_status === "flagged" ? "flagged" : "unknown",
+      reason: `Échec de l'analyse automatique : ${err.message}`,
+      payload: {
+        error: err.message,
+      },
+    };
+  }
+
+  const checkedAt = new Date().toISOString();
+  const flaggedAt =
+    evaluation.status === "flagged"
+      ? profile.reputation_flagged_at || checkedAt
+      : null;
+  const reviewedAt = evaluation.status === "safe" ? profile.reputation_reviewed_at : null;
+  const reviewedBy = evaluation.status === "safe" ? profile.reputation_reviewed_by : null;
+
+  await run(
+    `UPDATE ip_profiles
+        SET reputation_status=?,
+            reputation_provider=?,
+            reputation_reason=?,
+            reputation_payload=?,
+            reputation_checked_at=?,
+            reputation_flagged_at=?,
+            reputation_reviewed_at=?,
+            reputation_reviewed_by=?
+      WHERE id=?`,
+    [
+      evaluation.status,
+      PROVIDER_NAME,
+      evaluation.reason || null,
+      JSON.stringify(evaluation.payload ?? lookupResult ?? null),
+      checkedAt,
+      flaggedAt,
+      reviewedAt,
+      reviewedBy,
+      profile.id,
+    ],
+  );
+
+  return {
+    id: profile.id,
+    ip: normalized,
+    status: evaluation.status,
+    reason: evaluation.reason,
+    provider: PROVIDER_NAME,
+    checkedAt,
+    flaggedAt,
+  };
+}
+
+export async function autoRefreshIpReputation(ip) {
+  return refreshIpReputation(ip, { force: false });
+}
+
+export async function forceRefreshIpReputation(ip) {
+  return refreshIpReputation(ip, { force: true });
+}
+

--- a/views/admin/ip_profiles.ejs
+++ b/views/admin/ip_profiles.ejs
@@ -33,6 +33,7 @@
           <tr>
             <th>Profil</th>
             <th>Adresse IP</th>
+            <th>Statut</th>
             <th>Dernière activité</th>
             <th>Commentaires</th>
             <th>Propositions</th>
@@ -55,6 +56,22 @@
                 </small>
               </td>
               <td><code><%= profile.ip %></code></td>
+              <td>
+                <% const status = profile.reputation.status; %>
+                <span class="status-badge status-<%= status %>">
+                  <%= status === 'flagged' ? 'À vérifier' : status === 'safe' ? 'Sûr' : 'Inconnu' %>
+                </span>
+                <% if (profile.reputation.checkedAt) { %>
+                  <br />
+                  <small class="text-muted">
+                    Vérifié : <%= new Date(profile.reputation.checkedAt).toLocaleString('fr-FR') %>
+                  </small>
+                <% } %>
+                <% if (profile.reputation.reason) { %>
+                  <br />
+                  <small class="text-muted"><%= profile.reputation.reason %></small>
+                <% } %>
+              </td>
               <td>
                 <% if (profile.lastSeenAt) { %>
                   <time datetime="<%= profile.lastSeenAt %>"><%= new Date(profile.lastSeenAt).toLocaleString('fr-FR') %></time>

--- a/views/admin/ip_security.ejs
+++ b/views/admin/ip_security.ejs
@@ -1,0 +1,84 @@
+<% title = 'Sécurité IP'; %>
+<h1>Sécurité IP</h1>
+
+<section class="card card-highlight">
+  <p class="mt-0">
+    Ce module interroge l'API gratuite <strong>ip-api.com</strong> pour repérer automatiquement les
+    adresses IP associées à des proxies, VPN ou hébergeurs. Examinez les alertes ci-dessous pour
+    confirmer qu'il s'agit bien d'activités suspectes avant d'appliquer une sanction.
+  </p>
+</section>
+
+<% if (!flagged.length) { %>
+  <div class="alert alert-success mt-md">
+    Aucune adresse IP suspecte en attente de révision. Bravo !
+  </div>
+<% } else { %>
+  <div class="alert alert-warning mt-md">
+    <strong><%= flagged.length %></strong> adresse(s) IP nécessitent votre attention.
+  </div>
+  <section class="card mt-md">
+    <h2 class="mt-0">Adresses signalées</h2>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Profil</th>
+            <th>Adresse IP</th>
+            <th>Raison</th>
+            <th>Dernière vérification</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% flagged.forEach((ip) => { %>
+            <tr>
+              <td>
+                <strong>
+                  <a href="/profiles/ip/<%= ip.hash %>" target="_blank" rel="noopener">
+                    Profil #<%= ip.shortHash %>
+                  </a>
+                </strong>
+                <br />
+                <span class="status-badge status-flagged">À vérifier</span>
+              </td>
+              <td><code><%= ip.ip %></code></td>
+              <td>
+                <div><%= ip.reason %></div>
+                <% if (ip.provider) { %>
+                  <small class="text-muted">Source : <%= ip.provider %></small>
+                <% } %>
+              </td>
+              <td>
+                <% if (ip.flaggedAt) { %>
+                  <time datetime="<%= ip.flaggedAt %>"><%= new Date(ip.flaggedAt).toLocaleString('fr-FR') %></time>
+                <% } else if (ip.checkedAt) { %>
+                  <time datetime="<%= ip.checkedAt %>"><%= new Date(ip.checkedAt).toLocaleString('fr-FR') %></time>
+                <% } else { %>
+                  <span class="text-muted">Jamais</span>
+                <% } %>
+              </td>
+              <td>
+                <div class="flex flex-col gap-sm">
+                  <form method="post" action="/admin/ip-security/<%= ip.hash %>/ban" class="stack-form">
+                    <label class="stack-form">
+                      <span class="text-sm text-muted">Raison (optionnelle)</span>
+                      <input type="text" name="reason" placeholder="Motif du bannissement" />
+                    </label>
+                    <button class="btn danger" data-icon="🚫" type="submit">Bannir globalement</button>
+                  </form>
+                  <form method="post" action="/admin/ip-security/<%= ip.hash %>/mark-safe">
+                    <button class="btn secondary" data-icon="✅" type="submit">Marquer comme sûr</button>
+                  </form>
+                  <form method="post" action="/admin/ip-security/<%= ip.hash %>/recheck">
+                    <button class="btn secondary" data-icon="🔄" type="submit">Réanalyser</button>
+                  </form>
+                </div>
+              </td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+<% } %>

--- a/views/ip_profile.ejs
+++ b/views/ip_profile.ejs
@@ -22,6 +22,35 @@
       <dt>Dernière activité</dt>
       <dd><%= profile.lastSeenAt ? new Date(profile.lastSeenAt).toLocaleString('fr-FR') : 'Inconnue' %></dd>
     </div>
+    <div>
+      <dt>Statut de confiance</dt>
+      <dd>
+        <% const reputation = profile.reputation || {}; %>
+        <% const status = reputation.status || 'unknown'; %>
+        <span class="status-badge status-<%= status %>">
+          <%= status === 'flagged' ? 'À vérifier' : status === 'safe' ? 'Sûr' : 'Inconnu' %>
+        </span>
+        <% if (reputation.reason) { %>
+          <div class="text-muted"><%= reputation.reason %></div>
+        <% } %>
+        <div class="text-muted">
+          <% if (reputation.checkedAt) { %>
+            Vérifié automatiquement le <%= new Date(reputation.checkedAt).toLocaleString('fr-FR') %>
+            <% if (reputation.provider) { %>
+              (source : <%= reputation.provider %>)
+            <% } %>
+          <% } else { %>
+            Pas encore vérifié automatiquement.
+          <% } %>
+          <% if (reputation.reviewedBy) { %>
+            <br />Validé par <strong><%= reputation.reviewedBy %></strong>
+            <% if (reputation.reviewedAt) { %>
+              le <%= new Date(reputation.reviewedAt).toLocaleString('fr-FR') %>
+            <% } %>
+          <% } %>
+        </div>
+      </dd>
+    </div>
   </dl>
 
   <ul class="stat-grid ip-profile-stats">

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -68,6 +68,12 @@
           <% } %>
         </a>
         <a href="/admin/likes">❤️ Likes</a>
+        <a href="/admin/ip-security" class="nav-link nav-link--with-badge">
+          <span>🛡️ Sécurité IP</span>
+          <% if (adminCounts.flaggedIps) { %>
+            <span class="nav-badge" aria-label="Adresses à vérifier"><%= adminCounts.flaggedIps %></span>
+          <% } %>
+        </a>
         <a href="/admin/ip-bans">🚫 Blocages IP</a>
         <a href="/admin/ip-profiles">🧾 Profils IP</a>
         <a href="/admin/ban-appeals">📬 Demandes de déban</a>


### PR DESCRIPTION
## Summary
- integrate an automated IP reputation check using the ip-api.com service and store the results on each IP profile
- add an admin "Sécurité IP" dashboard with alerts, actionable controls to ban or approve flagged addresses, and a navigation badge that highlights pending reviews
- display reputation badges across existing IP profile pages and tables so moderators can quickly spot suspicious activity

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68da6798ec30832188d7f2fb2ea5cb2c