### PR TITLE
Add admin moderation controls for ban appeals

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,6 +53,7 @@ app.use(async (req, res, next) => {
           pendingComments: 0,
           pendingSubmissions: 0,
           suspiciousIps: 0,
+          pendingBanAppeals: 0,
           ...counts,
         };
       } catch (actionErr) {
@@ -61,6 +62,7 @@ app.use(async (req, res, next) => {
           pendingComments: 0,
           pendingSubmissions: 0,
           suspiciousIps: 0,
+          pendingBanAppeals: 0,
         };
       }
     }

--- a/db.js
+++ b/db.js
@@ -146,6 +146,10 @@ export async function initDb() {
     value TEXT,
     reason TEXT,
     message TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending'
+      CHECK(status IN ('pending','accepted','rejected')),
+    resolved_at DATETIME,
+    resolved_by TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
   );
   CREATE TABLE IF NOT EXISTS event_logs(
@@ -193,6 +197,13 @@ export async function initDb() {
   );
   await ensureColumn("ip_profiles", "is_abuser", "INTEGER NOT NULL DEFAULT 0");
   await ensureColumn("ip_profiles", "is_tor", "INTEGER NOT NULL DEFAULT 0");
+  await ensureColumn(
+    "ban_appeals",
+    "status",
+    "TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','accepted','rejected'))",
+  );
+  await ensureColumn("ban_appeals", "resolved_at", "DATETIME");
+  await ensureColumn("ban_appeals", "resolved_by", "TEXT");
   await ensureSnowflake("settings");
   await ensureSnowflake("users");
   await ensureSnowflake("pages");
@@ -209,6 +220,9 @@ export async function initDb() {
   await ensureSnowflake("ip_profiles");
   await ensureSnowflake("event_logs");
   await ensureSnowflake("uploads", "snowflake_id");
+  await db.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_ban_appeals_pending_ip ON ban_appeals(ip) WHERE ip IS NOT NULL AND status='pending'",
+  );
   return db;
 }
 

--- a/utils/adminTasks.js
+++ b/utils/adminTasks.js
@@ -1,18 +1,21 @@
 import { get } from "../db.js";
 import { countPageSubmissions } from "./pageSubmissionService.js";
 import { countSuspiciousIpProfiles } from "./ipProfiles.js";
+import { countBanAppeals } from "./banAppeals.js";
 
 export async function getAdminActionCounts() {
-  const [pendingCommentsRow, pendingSubmissions, suspiciousIps] =
+  const [pendingCommentsRow, pendingSubmissions, suspiciousIps, pendingAppeals] =
     await Promise.all([
       get("SELECT COUNT(*) AS total FROM comments WHERE status='pending'"),
       countPageSubmissions({ status: "pending" }),
       countSuspiciousIpProfiles(),
+      countBanAppeals({ status: "pending" }),
     ]);
 
   return {
     pendingComments: Number(pendingCommentsRow?.total ?? 0),
     pendingSubmissions: Number(pendingSubmissions ?? 0),
     suspiciousIps: Number(suspiciousIps ?? 0),
+    pendingBanAppeals: Number(pendingAppeals ?? 0),
   };
 }

--- a/views/admin/banAppeals.ejs
+++ b/views/admin/banAppeals.ejs
@@ -1,4 +1,5 @@
 <% title = 'Demandes de déban'; %>
+<% const selectedStatus = typeof statusFilter === 'string' ? statusFilter : 'all'; %>
 <h1>Demandes de débannissement</h1>
 
 <form method="get" class="card mb-md">
@@ -13,10 +14,19 @@
         class="flex-basis-260"
       />
     </label>
+    <label class="stack-form">
+      <span class="text-sm text-muted">Statut</span>
+      <select name="status" class="flex-basis-200">
+        <option value="all" <%= selectedStatus === 'all' ? 'selected' : '' %>>Tous</option>
+        <option value="pending" <%= selectedStatus === 'pending' ? 'selected' : '' %>>En attente</option>
+        <option value="accepted" <%= selectedStatus === 'accepted' ? 'selected' : '' %>>Acceptées</option>
+        <option value="rejected" <%= selectedStatus === 'rejected' ? 'selected' : '' %>>Refusées</option>
+      </select>
+    </label>
     <input type="hidden" name="page" value="1" />
     <input type="hidden" name="perPage" value="<%= pagination.perPage %>" />
     <button class="btn" data-icon="🔍" type="submit">Rechercher</button>
-    <% if (searchTerm) { %>
+    <% if (searchTerm || selectedStatus !== 'all') { %>
       <a class="btn secondary" href="/admin/ban-appeals">Réinitialiser</a>
     <% } %>
   </div>
@@ -38,6 +48,8 @@
             <th>Valeur</th>
             <th>Motif du ban</th>
             <th>Message de l'appel</th>
+            <th>Statut</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -57,6 +69,35 @@
               <td><%= appeal.reason || '-' %></td>
               <td>
                 <pre><%= appeal.message %></pre>
+              </td>
+              <td>
+                <% if (appeal.status === 'pending') { %>
+                  <span class="status-pill pending">En attente</span>
+                <% } else if (appeal.status === 'accepted') { %>
+                  <span class="status-pill approved">Acceptée</span>
+                <% } else { %>
+                  <span class="status-pill rejected">Refusée</span>
+                <% } %>
+                <% if (appeal.resolved_at) { %>
+                  <div class="text-sm text-muted">le <%= new Date(appeal.resolved_at).toLocaleString('fr-FR') %></div>
+                <% } %>
+                <% if (appeal.resolved_by) { %>
+                  <div class="text-sm text-muted">par <%= appeal.resolved_by %></div>
+                <% } %>
+              </td>
+              <td>
+                <% if (appeal.status === 'pending') { %>
+                  <div class="flex gap-sm flex-wrap">
+                    <form method="post" action="/admin/ban-appeals/<%= appeal.snowflake_id %>/accept">
+                      <button class="btn success" data-icon="✅" type="submit">Accepter</button>
+                    </form>
+                    <form method="post" action="/admin/ban-appeals/<%= appeal.snowflake_id %>/reject">
+                      <button class="btn danger" data-icon="✖️" type="submit">Refuser</button>
+                    </form>
+                  </div>
+                <% } else { %>
+                  <span class="text-muted">—</span>
+                <% } %>
               </td>
             </tr>
           <% }) %>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -76,7 +76,12 @@
           <% } %>
         </a>
         <a href="/admin/ip-profiles">🧾 Profils IP</a>
-        <a href="/admin/ban-appeals">📬 Demandes de déban</a>
+        <a href="/admin/ban-appeals" class="nav-link nav-link--with-badge">
+          <span>📬 Demandes de déban</span>
+          <% if (adminCounts.pendingBanAppeals) { %>
+            <span class="nav-badge" aria-label="Demandes de déban en attente"><%= adminCounts.pendingBanAppeals %></span>
+          <% } %>
+        </a>
         <a href="/admin/events">📜 Événements</a>
         <a href="/admin/uploads">🖼️ Images</a>
         <a href="/admin/settings">⚙️ Paramètres</a>


### PR DESCRIPTION
## Summary
- add status tracking and resolution metadata to ban appeals, including a unique constraint on active appeals
- expose admin filters, actions, and navigation badge updates for handling ban appeals
- block banned users from filing multiple simultaneous or repeat ban appeals once rejected

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68da6e62cfd08321bf2412e8f7ecbcbd