### PR TITLE
Add deletion controls for admin events and IP profiles

### DIFF
--- a/utils/ipProfiles.js
+++ b/utils/ipProfiles.js
@@ -603,6 +603,25 @@ export async function getRawIpProfileByHash(hash) {
   );
 }
 
+export async function deleteIpProfileByHash(hash) {
+  const normalized = normalizeIp(hash);
+  if (!normalized) {
+    return null;
+  }
+
+  const profile = await get(
+    `SELECT id, hash, ip FROM ip_profiles WHERE hash = ?`,
+    [normalized],
+  );
+  if (!profile?.id) {
+    return null;
+  }
+
+  await run(`DELETE FROM ip_profiles WHERE id = ?`, [profile.id]);
+
+  return { hash: profile.hash, ip: profile.ip };
+}
+
 export async function refreshIpReputationByHash(hash, { force = false } = {}) {
   const profile = await getRawIpProfileByHash(hash);
   if (!profile?.ip) {

--- a/views/admin/events.ejs
+++ b/views/admin/events.ejs
@@ -37,6 +37,7 @@
             <th>Utilisateur</th>
             <th>IP</th>
             <th>Date</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -48,6 +49,15 @@
               <td><%= ev.username || '-' %></td>
               <td><%= ev.ip || '-' %></td>
               <td><%= new Date(ev.created_at).toLocaleString('fr-FR') %></td>
+              <td>
+                <form
+                  method="post"
+                  action="/admin/events/<%= ev.id %>/delete"
+                  onsubmit="return confirm('Supprimer cet évènement ?');"
+                >
+                  <button class="btn danger" data-icon="🗑️" type="submit">Supprimer</button>
+                </form>
+              </td>
             </tr>
           <% }) %>
         </tbody>

--- a/views/admin/ip_profiles.ejs
+++ b/views/admin/ip_profiles.ejs
@@ -39,6 +39,7 @@
             <th>Propositions</th>
             <th>Likes</th>
             <th>Vues</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -94,6 +95,15 @@
               </td>
               <td>
                 <strong><%= profile.stats.views %></strong>
+              </td>
+              <td>
+                <form
+                  method="post"
+                  action="/admin/ip-profiles/<%= profile.hash %>/delete"
+                  onsubmit="return confirm('Supprimer ce profil IP ?');"
+                >
+                  <button class="btn danger" data-icon="🗑️" type="submit">Supprimer</button>
+                </form>
               </td>
             </tr>
           <% }) %>


### PR DESCRIPTION
## Summary
- add delete handlers in the admin router for individual event logs and IP profiles
- expose a helper to remove IP profiles and surface delete actions in the admin tables

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68da85814198832195d84a226b4baf2b