### PR TITLE
Improve wiki home page layout and styling

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -344,10 +344,32 @@ html.drawer-open .drawer-overlay {
   max-width: 1100px;
   width: 100%;
   justify-self: center;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  isolation: isolate;
 }
 
-.content > * + * {
-  margin-top: 1.5rem;
+.content::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  top: 1rem;
+  height: clamp(220px, 40vw, 360px);
+  background:
+    radial-gradient(120% 120% at 15% 15%, rgba(76, 110, 245, 0.2), transparent 55%),
+    radial-gradient(95% 95% at 85% 20%, rgba(249, 112, 112, 0.16), transparent 60%),
+    linear-gradient(140deg, rgba(20, 28, 48, 0.85), rgba(10, 14, 26, 0.6));
+  border-radius: clamp(180px, 48vw, 420px);
+  filter: blur(0);
+  opacity: 0.85;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.content > * {
+  margin: 0;
 }
 
 .site-footer {
@@ -356,6 +378,219 @@ html.drawer-open .drawer-overlay {
   font-size: 0.85rem;
   border-top: 1px solid rgba(255, 255, 255, 0.04);
   background: rgba(10, 12, 20, 0.7);
+}
+
+/* === HOMEPAGE HERO & SECTIONS === */
+.hero-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: 2.5rem;
+  padding: clamp(1.75rem, 2vw + 1.5rem, 2.75rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    linear-gradient(160deg, rgba(28, 39, 66, 0.88), rgba(12, 16, 28, 0.92)),
+    rgba(17, 23, 39, 0.65);
+  box-shadow: 0 25px 45px rgba(5, 8, 16, 0.55);
+  overflow: hidden;
+}
+
+.hero-card::after {
+  content: "";
+  position: absolute;
+  inset: -40% -35% auto auto;
+  width: clamp(260px, 45vw, 420px);
+  aspect-ratio: 1;
+  background: radial-gradient(circle, rgba(76, 110, 245, 0.35), transparent 65%);
+  opacity: 0.7;
+  filter: blur(0);
+  pointer-events: none;
+}
+
+.hero-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.hero-card__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.78rem;
+  color: rgba(219, 228, 255, 0.75);
+}
+
+.hero-card__title {
+  font-size: clamp(2.1rem, 3vw, 2.8rem);
+  letter-spacing: -0.03em;
+}
+
+.hero-card__lede {
+  margin: 0;
+  font-size: 1.05rem;
+  color: rgba(214, 221, 255, 0.88);
+  max-width: 42ch;
+}
+
+.hero-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.hero-card__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.stat-card {
+  position: relative;
+  padding: 1.15rem 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, rgba(20, 28, 48, 0.92), rgba(13, 18, 33, 0.88));
+  box-shadow: 0 18px 28px rgba(7, 10, 19, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.stat-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(76, 110, 245, 0.12), rgba(249, 112, 112, 0.08));
+  opacity: 0.8;
+  z-index: 0;
+}
+
+.stat-card__label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(219, 228, 255, 0.72);
+  z-index: 1;
+}
+
+.stat-card__value {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  z-index: 1;
+}
+
+.stat-card__hint {
+  font-size: 0.85rem;
+  color: rgba(219, 228, 255, 0.65);
+  z-index: 1;
+}
+
+.section-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 1vw + 1.25rem, 2rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: linear-gradient(160deg, rgba(18, 24, 42, 0.92), rgba(10, 15, 28, 0.88));
+  box-shadow: 0 22px 36px rgba(6, 9, 18, 0.45);
+}
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.section-heading--row {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.section-heading__meta {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.section-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.section-card .article-grid {
+  margin: 0;
+}
+
+.section-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.pagination-status {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.empty-card {
+  text-align: center;
+  color: var(--muted);
+  padding: 2rem;
+  border-style: dashed;
+}
+
+.page-size {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.page-size__control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.page-size__control select {
+  width: auto;
+  min-width: 70px;
+  background: rgba(17, 23, 39, 0.8);
+  border-color: rgba(255, 255, 255, 0.12);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 @media (max-width: 1024px) {
@@ -388,6 +623,15 @@ html.drawer-open .drawer-overlay {
     min-width: 0;
     flex: 1;
   }
+
+  .hero-card {
+    grid-template-columns: 1fr;
+    gap: 1.75rem;
+  }
+
+  .hero-card__stats {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
 }
 
 @media (max-width: 680px) {
@@ -405,6 +649,36 @@ html.drawer-open .drawer-overlay {
 
   .auth {
     margin-left: auto;
+  }
+
+  .hero-card__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .section-heading--row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .page-size {
+    justify-content: flex-start;
+  }
+
+  .page-size__control {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 520px) {
+  .stat-card__value {
+    font-size: 1.65rem;
+  }
+
+  .section-card {
+    padding: 1.35rem;
   }
 }
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,96 +1,156 @@
 <% title = 'Accueil'; %>
-<h1>Derniers articles (≤ 7 jours)</h1>
-<div class="article-grid">
-  <% if (recent.length === 0) { %><div class="card">Aucun article récent.</div><% } %>
-  <% recent.forEach(p => { const tags = (p.tagsCsv||'').split(',').filter(Boolean); %>
-    <div class="card">
-      <h3><strong><%= p.title %></strong></h3>
-      <% if (p.excerpt) { %>
-        <div class="excerpt">
-          <div class="excerpt-body"><%- p.excerpt %></div>
-        </div>
-      <% } %>
-      <% if (tags.length) { %>
-        <div class="tags-row">
-          <% tags.forEach(t => { %><a class="tag" href="/tags/<%= t %>"><%= t %></a><% }) %>
-        </div>
-      <% } %>
-      <div class="page-stats" aria-label="Statistiques de l’article">
-        <span title="Likes">💖 <strong data-like-count-for="<%= p.slug_id %>"><%= p.likes %></strong></span>
-        <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
-        <span title="Vues">👁️ <strong><%= p.views %></strong></span>
-      </div>
-      <div class="actions">
-        <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
-        <form action="/wiki/<%= p.slug_id %>/like" method="post" data-like-form-for="<%= p.slug_id %>">
-          <button
-            class="btn <%= p.userLiked ? 'unlike' : 'like' %>"
-            data-icon="<%= p.userLiked ? '💔' : '💖' %>"
-            data-label-liked="Retirer"
-            data-label-unliked="Like"
-            type="submit"
-          >
-            <%= p.userLiked ? 'Retirer' : 'Like' %> (<%= p.likes %>)
-          </button>
-        </form>
-        <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')">Copier le lien</button>
-      </div>
-      <small>Publié: <%= p.created_at %></small>
-    </div>
-  <% }) %>
-</div>
+<% const heroName = typeof wikiName !== 'undefined' && wikiName ? wikiName : 'le wiki'; %>
 
-<h2>Articles</h2>
-<form class="page-size" method="get" action="/">
-  <input type="hidden" name="page" value="1">
-  <label for="size">Articles par page :</label>
-  <select id="size" name="size" onchange="this.form.submit()">
-    <% sizeOptions.forEach(option => { %>
-      <option value="<%= option %>" <%= option === size ? 'selected' : '' %>><%= option %></option>
-    <% }) %>
-  </select>
-</form>
-<div class="article-grid">
-  <% rows.forEach(p => { const tags = (p.tagsCsv||'').split(',').filter(Boolean); %>
-    <div class="card">
-      <h3><strong><%= p.title %></strong></h3>
-      <% if (p.excerpt) { %>
-        <div class="excerpt">
-          <div class="excerpt-body"><%- p.excerpt %></div>
-        </div>
-      <% } %>
-      <% if (tags.length) { %>
-        <div class="tags-row">
-          <% tags.forEach(t => { %><a class="tag" href="/tags/<%= t %>"><%= t %></a><% }) %>
-        </div>
-      <% } %>
-      <div class="page-stats" aria-label="Statistiques de l’article">
-        <span title="Likes">💖 <strong data-like-count-for="<%= p.slug_id %>"><%= p.likes %></strong></span>
-        <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
-        <span title="Vues">👁️ <strong><%= p.views %></strong></span>
-      </div>
-      <div class="actions">
-        <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
-        <form action="/wiki/<%= p.slug_id %>/like" method="post" data-like-form-for="<%= p.slug_id %>">
-          <button
-            class="btn <%= p.userLiked ? 'unlike' : 'like' %>"
-            data-icon="<%= p.userLiked ? '💔' : '💖' %>"
-            data-label-liked="Retirer"
-            data-label-unliked="Like"
-            type="submit"
-          >
-            <%= p.userLiked ? 'Retirer' : 'Like' %> (<%= p.likes %>)
-          </button>
-        </form>
-        <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')">Copier le lien</button>
-      </div>
-      <small>Publié: <%= p.created_at %></small>
+<section class="hero-card">
+  <div class="hero-card__body">
+    <p class="hero-card__eyebrow">Bienvenue</p>
+    <h1 class="hero-card__title">Explorez <%= heroName %></h1>
+    <p class="hero-card__lede">
+      Une base de connaissances collaborative comptant <strong><%= total %></strong> articles publiés.
+    </p>
+    <div class="hero-card__actions">
+      <a class="btn success" data-icon="✨" href="/search">Rechercher un article</a>
+      <a class="btn" data-icon="✍️" href="/new">Écrire une page</a>
     </div>
-  <% }) %>
-</div>
+  </div>
+  <div class="hero-card__stats" aria-label="Indicateurs du wiki">
+    <div class="stat-card">
+      <span class="stat-card__label">Articles publiés</span>
+      <span class="stat-card__value"><%= total %></span>
+      <span class="stat-card__hint">depuis la création</span>
+    </div>
+    <div class="stat-card">
+      <span class="stat-card__label">Nouveautés</span>
+      <span class="stat-card__value"><%= recent.length %></span>
+      <span class="stat-card__hint">sur les 7 derniers jours</span>
+    </div>
+    <div class="stat-card">
+      <span class="stat-card__label">Articles listés</span>
+      <span class="stat-card__value"><%= rows.length %></span>
+      <span class="stat-card__hint">dans cette page</span>
+    </div>
+  </div>
+</section>
 
-<div class="actions">
-  <% if (page > 1) { %><a class="btn" data-icon="⬅️" href="/?page=<%= page-1 %>&size=<%= size %>">Précédent</a><% } %>
-  <span>Page <%= page %> / <%= totalPages %></span>
-  <% if (page < totalPages) { %><a class="btn" data-icon="➡️" href="/?page=<%= page+1 %>&size=<%= size %>">Suivant</a><% } %>
-</div>
+<section id="recent" class="section-card">
+  <div class="section-heading">
+    <h2>Derniers articles (≤ 7 jours)</h2>
+    <p class="section-heading__meta">
+      <% if (recent.length) { %>
+        <strong><%= recent.length %></strong> nouvelle<%= recent.length > 1 ? 's' : '' %> contribution<%= recent.length > 1 ? 's' : '' %> à découvrir.
+      <% } else { %>
+        Soyez la première personne à publier un contenu cette semaine !
+      <% } %>
+    </p>
+  </div>
+  <div class="section-body">
+    <% if (recent.length === 0) { %>
+      <div class="card empty-card">Aucun article récent.</div>
+    <% } else { %>
+      <div class="article-grid">
+        <% recent.forEach(p => { const tags = (p.tagsCsv||'').split(',').filter(Boolean); %>
+          <div class="card">
+            <h3><strong><%= p.title %></strong></h3>
+            <% if (p.excerpt) { %>
+              <div class="excerpt">
+                <div class="excerpt-body"><%- p.excerpt %></div>
+              </div>
+            <% } %>
+            <% if (tags.length) { %>
+              <div class="tags-row">
+                <% tags.forEach(t => { %><a class="tag" href="/tags/<%= t %>"><%= t %></a><% }) %>
+              </div>
+            <% } %>
+            <div class="page-stats" aria-label="Statistiques de l’article">
+              <span title="Likes">💖 <strong data-like-count-for="<%= p.slug_id %>"><%= p.likes %></strong></span>
+              <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
+              <span title="Vues">👁️ <strong><%= p.views %></strong></span>
+            </div>
+            <div class="actions">
+              <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
+              <form action="/wiki/<%= p.slug_id %>/like" method="post" data-like-form-for="<%= p.slug_id %>">
+                <button
+                  class="btn <%= p.userLiked ? 'unlike' : 'like' %>"
+                  data-icon="<%= p.userLiked ? '💔' : '💖' %>"
+                  data-label-liked="Retirer"
+                  data-label-unliked="Like"
+                  type="submit"
+                >
+                  <%= p.userLiked ? 'Retirer' : 'Like' %> (<%= p.likes %>)
+                </button>
+              </form>
+              <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')">Copier le lien</button>
+            </div>
+            <small>Publié: <%= p.created_at %></small>
+          </div>
+        <% }) %>
+      </div>
+    <% } %>
+  </div>
+</section>
+
+<section class="section-card">
+  <div class="section-heading section-heading--row">
+    <div>
+      <h2>Articles</h2>
+      <p class="section-heading__meta">Parcourez la totalité des contenus publiés.</p>
+    </div>
+    <form class="page-size" method="get" action="/">
+      <input type="hidden" name="page" value="1">
+      <label class="sr-only" for="size">Articles par page</label>
+      <div class="page-size__control">
+        <span>Articles par page</span>
+        <select id="size" name="size" onchange="this.form.submit()">
+          <% sizeOptions.forEach(option => { %>
+            <option value="<%= option %>" <%= option === size ? 'selected' : '' %>><%= option %></option>
+          <% }) %>
+        </select>
+      </div>
+    </form>
+  </div>
+  <div class="section-body">
+    <div class="article-grid">
+      <% rows.forEach(p => { const tags = (p.tagsCsv||'').split(',').filter(Boolean); %>
+        <div class="card">
+          <h3><strong><%= p.title %></strong></h3>
+          <% if (p.excerpt) { %>
+            <div class="excerpt">
+              <div class="excerpt-body"><%- p.excerpt %></div>
+            </div>
+          <% } %>
+          <% if (tags.length) { %>
+            <div class="tags-row">
+              <% tags.forEach(t => { %><a class="tag" href="/tags/<%= t %>"><%= t %></a><% }) %>
+            </div>
+          <% } %>
+          <div class="page-stats" aria-label="Statistiques de l’article">
+            <span title="Likes">💖 <strong data-like-count-for="<%= p.slug_id %>"><%= p.likes %></strong></span>
+            <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
+            <span title="Vues">👁️ <strong><%= p.views %></strong></span>
+          </div>
+          <div class="actions">
+            <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
+            <form action="/wiki/<%= p.slug_id %>/like" method="post" data-like-form-for="<%= p.slug_id %>">
+              <button
+                class="btn <%= p.userLiked ? 'unlike' : 'like' %>"
+                data-icon="<%= p.userLiked ? '💔' : '💖' %>"
+                data-label-liked="Retirer"
+                data-label-unliked="Like"
+                type="submit"
+              >
+                <%= p.userLiked ? 'Retirer' : 'Like' %> (<%= p.likes %>)
+              </button>
+            </form>
+            <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')">Copier le lien</button>
+          </div>
+          <small>Publié: <%= p.created_at %></small>
+        </div>
+      <% }) %>
+    </div>
+  </div>
+  <div class="section-footer actions">
+    <% if (page > 1) { %><a class="btn" data-icon="⬅️" href="/?page=<%= page-1 %>&size=<%= size %>">Précédent</a><% } %>
+    <span class="pagination-status">Page <strong><%= page %></strong> / <%= totalPages %></span>
+    <% if (page < totalPages) { %><a class="btn" data-icon="➡️" href="/?page=<%= page+1 %>&size=<%= size %>">Suivant</a><% } %>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add a welcoming hero card on the home page with quick actions and wiki indicators
- restyle the recent and paginated article sections with richer cards and supporting copy
- refresh shared layout spacing and gradients for a more modern feel across breakpoints

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68daa1a755908321a436de8e0317cd6b