### PR TITLE
Improve wiki home page interface

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -350,6 +350,158 @@ html.drawer-open .drawer-overlay {
   margin-top: 1.5rem;
 }
 
+.home-hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.65fr) minmax(0, 1fr);
+  gap: 2.5rem;
+  padding: 2.75rem 2.5rem;
+  background:
+    radial-gradient(circle at 20% 10%, rgba(76, 110, 245, 0.32), transparent 55%),
+    radial-gradient(circle at 85% 35%, rgba(249, 112, 112, 0.24), transparent 60%),
+    linear-gradient(135deg, rgba(15, 21, 36, 0.92), rgba(12, 17, 28, 0.94));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 45px rgba(4, 7, 14, 0.45);
+  overflow: hidden;
+}
+
+.home-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.08), transparent 45%);
+  pointer-events: none;
+}
+
+.hero-intro {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.hero-eyebrow {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(219, 228, 255, 0.75);
+}
+
+.hero-title {
+  margin: 0;
+  font-size: clamp(2rem, 3.2vw, 2.6rem);
+  line-height: 1.2;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.hero-lede {
+  margin: 0;
+  font-size: 1.05rem;
+  color: rgba(222, 229, 255, 0.78);
+  max-width: 48ch;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.hero-actions .btn {
+  min-width: 0;
+}
+
+.hero-stats {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.1rem;
+  align-content: start;
+  background: rgba(8, 11, 20, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  backdrop-filter: blur(6px);
+}
+
+.hero-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.hero-stat dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(223, 228, 255, 0.6);
+  margin: 0;
+}
+
+.hero-stat dd {
+  margin: 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.hero-stat small {
+  color: rgba(204, 213, 244, 0.72);
+  font-size: 0.8rem;
+}
+
+.home-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  background: rgba(12, 17, 28, 0.65);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 1.75rem 1.8rem 2rem;
+  box-shadow: 0 12px 32px rgba(6, 9, 16, 0.35);
+}
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.25rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.section-heading-text {
+  max-width: min(60ch, 100%);
+}
+
+.section-heading-text h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.6rem;
+  letter-spacing: -0.01em;
+}
+
+.section-heading-text p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.page-size {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: rgba(8, 11, 20, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+}
+
 .site-footer {
   padding: 1.5rem 2.5rem 2.5rem;
   color: var(--muted);
@@ -388,6 +540,15 @@ html.drawer-open .drawer-overlay {
     min-width: 0;
     flex: 1;
   }
+
+  .home-hero {
+    grid-template-columns: 1fr;
+    padding: 2.4rem 2rem;
+  }
+
+  .hero-stats {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
 }
 
 @media (max-width: 680px) {
@@ -405,6 +566,49 @@ html.drawer-open .drawer-overlay {
 
   .auth {
     margin-left: auto;
+  }
+
+  .home-hero {
+    gap: 2rem;
+    padding: 2rem 1.6rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .hero-actions .btn {
+    width: 100%;
+  }
+
+  .hero-stats {
+    padding: 1.25rem;
+  }
+
+  .home-section {
+    padding: 1.5rem 1.25rem 1.75rem;
+  }
+
+  .section-heading {
+    align-items: flex-start;
+  }
+
+  .page-size {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.6rem;
+  }
+
+  .page-size label,
+  .page-size select {
+    width: 100%;
+    text-align: center;
+  }
+
+  .card-actions .btn {
+    flex: 1 1 100%;
   }
 }
 
@@ -631,6 +835,88 @@ html.drawer-open .drawer-overlay {
   padding: 1.1rem 1.25rem 1.35rem;
 }
 
+.article-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 100%;
+}
+
+.article-card--recent {
+  border-color: rgba(76, 110, 245, 0.4);
+  box-shadow: 0 18px 40px rgba(44, 64, 116, 0.38);
+  background: linear-gradient(180deg, rgba(50, 67, 117, 0.55), rgba(15, 21, 36, 0.92));
+}
+
+.card-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem 1rem;
+  align-items: flex-start;
+}
+
+.card-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.card-title {
+  margin: 0;
+  font-size: 1.2rem;
+  line-height: 1.35;
+}
+
+.card-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.card-meta {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.card-footer {
+  margin-top: auto;
+  padding-top: 1.1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.card-actions form {
+  margin: 0;
+}
+
+.card-actions .btn {
+  flex: 1 1 150px;
+}
+
+.card-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-height: 140px;
+  color: rgba(220, 226, 248, 0.76);
+  font-weight: 500;
+}
+
 .excerpt {
   margin: 0.75rem 0;
   color: var(--muted);
@@ -673,6 +959,17 @@ html.drawer-open .drawer-overlay {
   margin: 0.85rem 0;
   font-size: 0.9rem;
   color: var(--muted);
+}
+
+.pagination {
+  justify-content: center;
+  gap: 0.9rem;
+  margin-top: 2rem;
+}
+
+.pagination-status {
+  font-size: 0.95rem;
+  color: rgba(219, 229, 255, 0.75);
 }
 
 .page-header {
@@ -750,6 +1047,33 @@ label {
   display: flex;
   flex-direction: column;
   margin-bottom: 1rem;
+}
+
+.page-size label {
+  margin: 0;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(219, 229, 255, 0.6);
+  display: inline-flex;
+  align-items: center;
+}
+
+.page-size select {
+  width: auto;
+  min-width: 4.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  border: none;
+  padding: 0.35rem 0.75rem;
+  font-weight: 600;
+  color: #fff;
+  cursor: pointer;
+}
+
+.page-size select:focus {
+  border: none;
+  box-shadow: 0 0 0 2px rgba(76, 110, 245, 0.4);
 }
 
 .form-error {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,96 +1,182 @@
 <% title = 'Accueil'; %>
-<h1>Derniers articles (≤ 7 jours)</h1>
-<div class="article-grid">
-  <% if (recent.length === 0) { %><div class="card">Aucun article récent.</div><% } %>
-  <% recent.forEach(p => { const tags = (p.tagsCsv||'').split(',').filter(Boolean); %>
-    <div class="card">
-      <h3><strong><%= p.title %></strong></h3>
-      <% if (p.excerpt) { %>
-        <div class="excerpt">
-          <div class="excerpt-body"><%- p.excerpt %></div>
-        </div>
-      <% } %>
-      <% if (tags.length) { %>
-        <div class="tags-row">
-          <% tags.forEach(t => { %><a class="tag" href="/tags/<%= t %>"><%= t %></a><% }) %>
-        </div>
-      <% } %>
-      <div class="page-stats" aria-label="Statistiques de l’article">
-        <span title="Likes">💖 <strong data-like-count-for="<%= p.slug_id %>"><%= p.likes %></strong></span>
-        <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
-        <span title="Vues">👁️ <strong><%= p.views %></strong></span>
-      </div>
-      <div class="actions">
-        <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
-        <form action="/wiki/<%= p.slug_id %>/like" method="post" data-like-form-for="<%= p.slug_id %>">
-          <button
-            class="btn <%= p.userLiked ? 'unlike' : 'like' %>"
-            data-icon="<%= p.userLiked ? '💔' : '💖' %>"
-            data-label-liked="Retirer"
-            data-label-unliked="Like"
-            type="submit"
-          >
-            <%= p.userLiked ? 'Retirer' : 'Like' %> (<%= p.likes %>)
-          </button>
-        </form>
-        <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')">Copier le lien</button>
-      </div>
-      <small>Publié: <%= p.created_at %></small>
-    </div>
-  <% }) %>
-</div>
 
-<h2>Articles</h2>
-<form class="page-size" method="get" action="/">
-  <input type="hidden" name="page" value="1">
-  <label for="size">Articles par page :</label>
-  <select id="size" name="size" onchange="this.form.submit()">
-    <% sizeOptions.forEach(option => { %>
-      <option value="<%= option %>" <%= option === size ? 'selected' : '' %>><%= option %></option>
+<section class="home-hero">
+  <div class="hero-intro">
+    <p class="hero-eyebrow">Bienvenue sur <%= typeof wikiName !== 'undefined' ? wikiName : 'le wiki' %></p>
+    <h1 class="hero-title">Explorez le savoir collectif et partagez vos découvertes</h1>
+    <p class="hero-lede">
+      Consultez les dernières contributions de la communauté, enregistrez vos favoris et aidez à enrichir la
+      connaissance commune.
+    </p>
+    <div class="hero-actions">
+      <a class="btn success" data-icon="✨" href="/search">Parcourir le contenu</a>
+      <a class="btn secondary" data-icon="✍️" href="/new">Proposer un article</a>
+    </div>
+  </div>
+  <dl class="hero-stats" aria-label="Statistiques principales du wiki">
+    <div class="hero-stat">
+      <dt>Articles publiés</dt>
+      <dd><strong><%= total %></strong></dd>
+      <small>Un index qui s’étoffe jour après jour.</small>
+    </div>
+    <div class="hero-stat">
+      <dt>Nouveautés (7 derniers jours)</dt>
+      <dd><strong><%= recent.length %></strong></dd>
+      <small>Dernières entrées des contributrices et contributeurs.</small>
+    </div>
+    <div class="hero-stat">
+      <dt>Articles affichés</dt>
+      <dd><strong><%= rows.length %></strong></dd>
+      <small>Selon vos paramètres de pagination.</small>
+    </div>
+  </dl>
+</section>
+
+<section class="home-section">
+  <div class="section-heading">
+    <div class="section-heading-text">
+      <h2>Dernières publications</h2>
+      <p>Les articles fraîchement publiés au cours des sept derniers jours.</p>
+    </div>
+  </div>
+  <div class="article-grid">
+    <% if (recent.length === 0) { %>
+      <div class="card card-empty">Aucun article récent n’a encore été publié. Revenez bientôt !</div>
+    <% } %>
+    <% recent.forEach(p => {
+      const tags = (p.tagsCsv||'').split(',').filter(Boolean);
+      const createdDate = new Date(p.created_at);
+      const createdIso = !Number.isNaN(createdDate.valueOf()) ? createdDate.toISOString() : null;
+    %>
+      <article class="card article-card article-card--recent">
+        <header class="card-header">
+          <div class="card-title-group">
+            <h3 class="card-title"><strong><%= p.title %></strong></h3>
+            <span class="card-badge">🆕 Nouveau</span>
+          </div>
+          <time class="card-meta" <%= createdIso ? `datetime="${createdIso}"` : '' %>>Publié : <%= p.created_at %></time>
+        </header>
+        <% if (p.excerpt) { %>
+          <div class="excerpt">
+            <div class="excerpt-body"><%- p.excerpt %></div>
+          </div>
+        <% } %>
+        <% if (tags.length) { %>
+          <div class="tags-row">
+            <% tags.forEach(t => { %><a class="tag" href="/tags/<%= t %>"><%= t %></a><% }) %>
+          </div>
+        <% } %>
+        <div class="page-stats" aria-label="Statistiques de l’article">
+          <span title="Likes">💖 <strong data-like-count-for="<%= p.slug_id %>"><%= p.likes %></strong></span>
+          <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
+          <span title="Vues">👁️ <strong><%= p.views %></strong></span>
+        </div>
+        <footer class="card-footer">
+          <div class="card-actions">
+            <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
+            <form action="/wiki/<%= p.slug_id %>/like" method="post" data-like-form-for="<%= p.slug_id %>">
+              <button
+                class="btn <%= p.userLiked ? 'unlike' : 'like' %>"
+                data-icon="<%= p.userLiked ? '💔' : '💖' %>"
+                data-label-liked="Retirer"
+                data-label-unliked="Like"
+                type="submit"
+              >
+                <%= p.userLiked ? 'Retirer' : 'Like' %> (<%= p.likes %>)
+              </button>
+            </form>
+            <button
+              class="btn copy"
+              data-icon="🔗"
+              type="button"
+              onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')"
+            >
+              Copier le lien
+            </button>
+          </div>
+        </footer>
+      </article>
     <% }) %>
-  </select>
-</form>
-<div class="article-grid">
-  <% rows.forEach(p => { const tags = (p.tagsCsv||'').split(',').filter(Boolean); %>
-    <div class="card">
-      <h3><strong><%= p.title %></strong></h3>
-      <% if (p.excerpt) { %>
-        <div class="excerpt">
-          <div class="excerpt-body"><%- p.excerpt %></div>
-        </div>
-      <% } %>
-      <% if (tags.length) { %>
-        <div class="tags-row">
-          <% tags.forEach(t => { %><a class="tag" href="/tags/<%= t %>"><%= t %></a><% }) %>
-        </div>
-      <% } %>
-      <div class="page-stats" aria-label="Statistiques de l’article">
-        <span title="Likes">💖 <strong data-like-count-for="<%= p.slug_id %>"><%= p.likes %></strong></span>
-        <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
-        <span title="Vues">👁️ <strong><%= p.views %></strong></span>
-      </div>
-      <div class="actions">
-        <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
-        <form action="/wiki/<%= p.slug_id %>/like" method="post" data-like-form-for="<%= p.slug_id %>">
-          <button
-            class="btn <%= p.userLiked ? 'unlike' : 'like' %>"
-            data-icon="<%= p.userLiked ? '💔' : '💖' %>"
-            data-label-liked="Retirer"
-            data-label-unliked="Like"
-            type="submit"
-          >
-            <%= p.userLiked ? 'Retirer' : 'Like' %> (<%= p.likes %>)
-          </button>
-        </form>
-        <button class="btn copy" data-icon="🔗" onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')">Copier le lien</button>
-      </div>
-      <small>Publié: <%= p.created_at %></small>
-    </div>
-  <% }) %>
-</div>
+  </div>
+</section>
 
-<div class="actions">
-  <% if (page > 1) { %><a class="btn" data-icon="⬅️" href="/?page=<%= page-1 %>&size=<%= size %>">Précédent</a><% } %>
-  <span>Page <%= page %> / <%= totalPages %></span>
-  <% if (page < totalPages) { %><a class="btn" data-icon="➡️" href="/?page=<%= page+1 %>&size=<%= size %>">Suivant</a><% } %>
+<section class="home-section">
+  <div class="section-heading">
+    <div class="section-heading-text">
+      <h2>Tous les articles</h2>
+      <p>Parcourez l’ensemble des contenus disponibles sur la plateforme.</p>
+    </div>
+    <form class="page-size" method="get" action="/">
+      <input type="hidden" name="page" value="1">
+      <label for="size">Articles par page</label>
+      <select id="size" name="size" onchange="this.form.submit()">
+        <% sizeOptions.forEach(option => { %>
+          <option value="<%= option %>" <%= option === size ? 'selected' : '' %>><%= option %></option>
+        <% }) %>
+      </select>
+    </form>
+  </div>
+  <div class="article-grid">
+    <% rows.forEach(p => {
+      const tags = (p.tagsCsv||'').split(',').filter(Boolean);
+      const createdDate = new Date(p.created_at);
+      const createdIso = !Number.isNaN(createdDate.valueOf()) ? createdDate.toISOString() : null;
+    %>
+      <article class="card article-card">
+        <header class="card-header">
+          <h3 class="card-title"><strong><%= p.title %></strong></h3>
+          <time class="card-meta" <%= createdIso ? `datetime="${createdIso}"` : '' %>>Publié : <%= p.created_at %></time>
+        </header>
+        <% if (p.excerpt) { %>
+          <div class="excerpt">
+            <div class="excerpt-body"><%- p.excerpt %></div>
+          </div>
+        <% } %>
+        <% if (tags.length) { %>
+          <div class="tags-row">
+            <% tags.forEach(t => { %><a class="tag" href="/tags/<%= t %>"><%= t %></a><% }) %>
+          </div>
+        <% } %>
+        <div class="page-stats" aria-label="Statistiques de l’article">
+          <span title="Likes">💖 <strong data-like-count-for="<%= p.slug_id %>"><%= p.likes %></strong></span>
+          <span title="Commentaires">💬 <strong><%= p.comment_count %></strong></span>
+          <span title="Vues">👁️ <strong><%= p.views %></strong></span>
+        </div>
+        <footer class="card-footer">
+          <div class="card-actions">
+            <a class="btn success" data-icon="📖" href="/wiki/<%= p.slug_id %>">Ouvrir l’article</a>
+            <form action="/wiki/<%= p.slug_id %>/like" method="post" data-like-form-for="<%= p.slug_id %>">
+              <button
+                class="btn <%= p.userLiked ? 'unlike' : 'like' %>"
+                data-icon="<%= p.userLiked ? '💔' : '💖' %>"
+                data-label-liked="Retirer"
+                data-label-unliked="Like"
+                type="submit"
+              >
+                <%= p.userLiked ? 'Retirer' : 'Like' %> (<%= p.likes %>)
+              </button>
+            </form>
+            <button
+              class="btn copy"
+              data-icon="🔗"
+              type="button"
+              onclick="navigator.clipboard.writeText(location.origin + '/wiki/<%= p.slug_id %>')"
+            >
+              Copier le lien
+            </button>
+          </div>
+        </footer>
+      </article>
+    <% }) %>
+  </div>
+</section>
+
+<div class="actions pagination">
+  <% if (page > 1) { %>
+    <a class="btn" data-icon="⬅️" href="/?page=<%= page-1 %>&size=<%= size %>">Précédent</a>
+  <% } %>
+  <span class="pagination-status">Page <strong><%= page %></strong> / <%= totalPages %></span>
+  <% if (page < totalPages) { %>
+    <a class="btn" data-icon="➡️" href="/?page=<%= page+1 %>&size=<%= size %>">Suivant</a>
+  <% } %>
 </div>


### PR DESCRIPTION
## Summary
- add a hero banner on the landing page with quick wiki statistics and clear calls to action
- redesign article cards with richer metadata, contextual badges, and refreshed action layouts
- update global styling to support the new sections, improved pagination, and responsive behaviour

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68daa1a755908321a436de8e0317cd6b