### PR TITLE
feat: allow admins to manage changelog versions

### DIFF
--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -1,5 +1,6 @@
 [
   {
+    "version": "1.1.0",
     "date": "2024-06-07",
     "title": "Améliorations de modération et nouveautés interface",
     "details": [

--- a/public/style.css
+++ b/public/style.css
@@ -1116,6 +1116,123 @@ label {
   padding: 0.35rem;
 }
 
+/* === ADMIN CHANGELOG === */
+.admin-changelog-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.admin-changelog-item {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  padding: 1.2rem;
+  background: linear-gradient(180deg, rgba(22, 28, 44, 0.85), rgba(12, 16, 28, 0.92));
+  box-shadow: 0 14px 32px rgba(5, 8, 17, 0.32);
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.admin-changelog-item-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem 1rem;
+}
+
+.admin-changelog-item-version {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(219, 228, 255, 0.75);
+}
+
+.admin-changelog-item-version strong {
+  font-size: 1.05rem;
+  margin-left: 0.35rem;
+  color: #ffffff;
+}
+
+.admin-changelog-item-title {
+  margin: 0.35rem 0 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #f8f9ff;
+}
+
+.admin-changelog-item-header time {
+  font-size: 0.9rem;
+  color: rgba(219, 228, 255, 0.7);
+}
+
+.admin-changelog-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.admin-changelog-form {
+  max-width: 640px;
+}
+
+.admin-changelog-form textarea {
+  min-height: 150px;
+}
+
+.admin-changelog-form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.admin-changelog-delete {
+  margin: 0;
+}
+
+.changelog-error-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.changelog-entry-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem 1rem;
+  align-items: flex-start;
+}
+
+.changelog-entry-version {
+  margin: 0;
+  font-size: 0.88rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(219, 228, 255, 0.7);
+}
+
+.changelog-entry-version span {
+  margin-left: 0.35rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.changelog-entry-title {
+  margin: 0.35rem 0 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #f8f9ff;
+}
+
 /* === TABLES === */
 .table-wrap {
   overflow-x: auto;

--- a/views/admin/changelog.ejs
+++ b/views/admin/changelog.ejs
@@ -1,0 +1,106 @@
+<% title = 'Changelog'; %>
+<h1>Gestion du changelog</h1>
+
+<section class="card">
+  <header class="card-header">
+    <h2 class="mt-0">Ajouter une nouvelle version</h2>
+    <p class="text-muted mt-xs">Renseignez la version, la date et les changements associés. Les détails sont enregistrés ligne par ligne.</p>
+  </header>
+
+  <% if (errors && errors.length) { %>
+    <div class="alert alert-error mt-sm" role="alert">
+      <ul class="changelog-error-list">
+        <% errors.forEach(function(error) { %>
+          <li><%= error %></li>
+        <% }); %>
+      </ul>
+    </div>
+  <% } %>
+
+  <form method="post" action="/admin/changelog" class="stack-form mt-md">
+    <label>
+      Version
+      <input type="text" name="version" value="<%= formValues && formValues.version ? formValues.version : '' %>" required />
+    </label>
+    <label>
+      Date de publication
+      <input type="date" name="date" value="<%= formValues && formValues.date ? formValues.date : '' %>" />
+      <p class="help-text">Laissez vide pour utiliser la date du jour.</p>
+    </label>
+    <label>
+      Titre
+      <input type="text" name="title" value="<%= formValues && formValues.title ? formValues.title : '' %>" />
+      <p class="help-text">Optionnel, sera remplacé par "Version X" si vide.</p>
+    </label>
+    <label>
+      Détails de la version
+      <textarea name="details" rows="6" placeholder="Une amélioration par ligne" required><%= formValues && formValues.details ? formValues.details : '' %></textarea>
+    </label>
+    <button type="submit" class="btn">Ajouter la version</button>
+  </form>
+</section>
+
+<section class="card mt-xl">
+  <header class="card-header">
+    <h2 class="mt-0">Versions publiées</h2>
+    <p class="text-muted mt-xs">Modifiez ou supprimez une version existante. Les éléments sont triés du plus récent au plus ancien.</p>
+  </header>
+
+  <% if (!entries || !entries.length) { %>
+    <p class="text-muted mt-md">Aucune version n'a encore été enregistrée.</p>
+  <% } else { %>
+    <ul class="admin-changelog-list mt-md">
+      <% entries.forEach(function(entry) { %>
+        <li class="admin-changelog-item">
+          <header class="admin-changelog-item-header">
+            <div>
+              <p class="admin-changelog-item-version">Version <strong><%= entry.version || 'Non définie' %></strong></p>
+              <p class="admin-changelog-item-title"><%= entry.title %></p>
+            </div>
+            <% if (entry.date) { %>
+              <time datetime="<%= entry.date %>"><%= entry.date %></time>
+            <% } %>
+          </header>
+
+          <div class="admin-changelog-item-body">
+            <form method="post" action="/admin/changelog/<%= entry.index %>/update" class="stack-form admin-changelog-form">
+              <label>
+                Version
+                <input type="text" name="version" value="<%= entry.version %>" required />
+              </label>
+              <label>
+                Date de publication
+                <input type="date" name="date" value="<%= entry.date || '' %>" />
+              </label>
+              <label>
+                Titre
+                <input type="text" name="title" value="<%= entry.title %>" />
+              </label>
+              <label>
+                Détails de la version
+                <textarea name="details" rows="5" required><%= entry.detailsText %></textarea>
+              </label>
+              <div class="admin-changelog-form-actions">
+                <button type="submit" class="btn">Mettre à jour</button>
+                <button
+                  type="submit"
+                  class="btn danger"
+                  form="delete-form-<%= entry.index %>"
+                  onclick="return confirm(<%= JSON.stringify(`Supprimer définitivement la version ${entry.version || ''} ?`) %>);"
+                >
+                  Supprimer
+                </button>
+              </div>
+            </form>
+            <form
+              method="post"
+              action="/admin/changelog/<%= entry.index %>/delete"
+              id="delete-form-<%= entry.index %>"
+              class="admin-changelog-delete"
+            ></form>
+          </div>
+        </li>
+      <% }); %>
+    </ul>
+  <% } %>
+</section>

--- a/views/changelog.ejs
+++ b/views/changelog.ejs
@@ -14,7 +14,12 @@
       <% entries.forEach(entry => { %>
         <li class="changelog-entry">
           <div class="changelog-entry-header">
-            <h2><%= entry.title %></h2>
+            <div>
+              <% if (entry.version) { %>
+                <p class="changelog-entry-version">Version <span><%= entry.version %></span></p>
+              <% } %>
+              <h2 class="changelog-entry-title"><%= entry.title %></h2>
+            </div>
             <% if (entry.date) { %>
               <time datetime="<%= entry.date %>">
                 <%= new Date(entry.date).toLocaleDateString('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' }) %>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -92,6 +92,7 @@
           <% } %>
         </a>
         <a href="/admin/events">📜 Événements</a>
+        <a href="/admin/changelog">🛠️ Changelog</a>
         <a href="/admin/uploads">🖼️ Images</a>
         <a href="/admin/settings">⚙️ Paramètres</a>
       <% } %>


### PR DESCRIPTION
## Summary
- add an admin changelog management page to create, edit, and delete versioned entries with dedicated styling
- persist changelog entries with version identifiers and expose version badges on the public changelog
- extend changelog utilities and admin navigation to support saving entries from the interface

## Testing
- node --check routes/admin.js
- node --check utils/changelog.js

------
https://chatgpt.com/codex/tasks/task_e_68daa514f018832197da3e9f86990bde