### PR TITLE
Add IP reputation check history to admin surveillance page

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -25,6 +25,7 @@ import {
   fetchIpProfiles,
   listIpProfilesForReview,
   fetchRecentlyClearedProfiles,
+  fetchRecentIpReputationChecks,
   markIpProfileSafe,
   markIpProfileBanned,
   refreshIpReputationByHash,
@@ -636,9 +637,10 @@ r.post("/ip-bans/:id/delete", async (req, res) => {
 });
 
 r.get("/ip-reputation", async (req, res) => {
-  const [suspicious, cleared] = await Promise.all([
+  const [suspicious, cleared, history] = await Promise.all([
     listIpProfilesForReview({ limit: 100 }),
     fetchRecentlyClearedProfiles({ limit: 8 }),
+    fetchRecentIpReputationChecks({ limit: 20 }),
   ]);
   const refreshIntervalHours = Math.round(
     (IP_REPUTATION_REFRESH_INTERVAL_MS / (60 * 60 * 1000)) * 10,
@@ -646,6 +648,7 @@ r.get("/ip-reputation", async (req, res) => {
   res.render("admin/ip_reputation", {
     suspicious,
     cleared,
+    history,
     refreshIntervalHours,
     providerName: "ipapi.is",
   });

--- a/utils/ipProfiles.js
+++ b/utils/ipProfiles.js
@@ -794,6 +794,31 @@ export async function listIpProfilesForReview({ limit = 50 } = {}) {
   }));
 }
 
+export async function fetchRecentIpReputationChecks({ limit = 20 } = {}) {
+  const safeLimit = Number.isInteger(limit) && limit > 0 ? limit : 20;
+  const rows = await all(
+    `SELECT hash, ip, reputation_status, reputation_auto_status, reputation_override,
+            reputation_summary, reputation_checked_at, last_seen_at
+       FROM ip_profiles
+      WHERE reputation_checked_at IS NOT NULL
+      ORDER BY reputation_checked_at DESC
+      LIMIT ?`,
+    [safeLimit],
+  );
+
+  return rows.map((row) => ({
+    hash: row.hash,
+    shortHash: formatIpProfileLabel(row.hash),
+    ip: row.ip,
+    status: row.reputation_status || "unknown",
+    autoStatus: row.reputation_auto_status || "unknown",
+    override: normalizeOverride(row.reputation_override),
+    summary: row.reputation_summary || null,
+    checkedAt: row.reputation_checked_at || null,
+    lastSeenAt: row.last_seen_at || null,
+  }));
+}
+
 export async function fetchRecentlyClearedProfiles({ limit = 10 } = {}) {
   const safeLimit = Number.isInteger(limit) && limit > 0 ? limit : 10;
   const rows = await all(

--- a/views/admin/ip_reputation.ejs
+++ b/views/admin/ip_reputation.ejs
@@ -1,4 +1,19 @@
 <% title = 'Surveillance IP'; %>
+<%
+  const historyEntries = Array.isArray(history) ? history : [];
+  function formatReputationStatusLabel(status) {
+    if (status === 'suspicious') return 'Suspecte';
+    if (status === 'safe') return 'Validée';
+    if (status === 'clean') return 'Neutre';
+    return 'Inconnue';
+  }
+  function getReputationStatusClass(status) {
+    if (status === 'suspicious') return 'status-pill suspicious';
+    if (status === 'safe') return 'status-pill safe';
+    if (status === 'clean') return 'status-pill clean';
+    return 'status-pill pending';
+  }
+%>
 <h1>Surveillance des IP à risque</h1>
 
 <p class="text-muted leading-snug">
@@ -134,5 +149,68 @@
         </li>
       <% }) %>
     </ul>
+  <% } %>
+</section>
+
+<section class="card">
+  <h2 class="mt-0">Historique des analyses</h2>
+  <% if (!historyEntries.length) { %>
+    <p class="text-muted">Aucune analyse d'adresse IP n'a encore été enregistrée.</p>
+  <% } else { %>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Adresse IP</th>
+            <th>Statut</th>
+            <th>Résumé</th>
+            <th>Dernière vérification</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% historyEntries.forEach((entry) => { %>
+            <tr>
+              <td>
+                <code><%= entry.ip %></code>
+                <br />
+                <small class="text-muted">Profil #<%= entry.shortHash %></small>
+              </td>
+              <td>
+                <span class="<%= getReputationStatusClass(entry.status) %>">
+                  <%= formatReputationStatusLabel(entry.status) %>
+                </span>
+                <% if (entry.override) { %>
+                  <br />
+                  <small class="text-muted">Forçage : <%= entry.override %></small>
+                <% } %>
+              </td>
+              <td>
+                <%= entry.summary || "Aucun signal particulier détecté." %>
+              </td>
+              <td>
+                <% if (entry.checkedAt) { %>
+                  <time datetime="<%= entry.checkedAt %>">
+                    <%= new Date(entry.checkedAt).toLocaleString('fr-FR') %>
+                  </time>
+                <% } else { %>
+                  <span class="text-muted">Jamais</span>
+                <% } %>
+              </td>
+              <td>
+                <a
+                  class="btn secondary btn-compact"
+                  href="/profiles/ip/<%= entry.hash %>"
+                  target="_blank"
+                  rel="noopener"
+                >
+                  Voir le profil
+                </a>
+              </td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
   <% } %>
 </section>


### PR DESCRIPTION
## Summary
- add a helper to list recent IP reputation checks from stored profiles
- include the history feed when rendering the admin IP surveillance view
- render a table of recent analysis results so manual checks appear in the history

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dab7433414832191968e3ff405544d