### PR TITLE
Handle no-op admin comment moderation

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -215,7 +215,24 @@ r.post("/comments/:id/approve", async (req, res) => {
     });
     return redirectToComments(req, res);
   }
-  await run("UPDATE comments SET status='approved' WHERE id=?", [comment.id]);
+  if (comment.status === "approved") {
+    pushNotification(req, {
+      type: "info",
+      message: "Ce commentaire est déjà approuvé.",
+    });
+    return redirectToComments(req, res);
+  }
+  const result = await run(
+    "UPDATE comments SET status='approved', updated_at=CURRENT_TIMESTAMP WHERE id=?",
+    [comment.id],
+  );
+  if (!result?.changes) {
+    pushNotification(req, {
+      type: "error",
+      message: "Impossible d'approuver ce commentaire.",
+    });
+    return redirectToComments(req, res);
+  }
   comment.status = "approved";
   pushNotification(req, {
     type: "success",
@@ -238,7 +255,24 @@ r.post("/comments/:id/reject", async (req, res) => {
     });
     return redirectToComments(req, res);
   }
-  await run("UPDATE comments SET status='rejected' WHERE id=?", [comment.id]);
+  if (comment.status === "rejected") {
+    pushNotification(req, {
+      type: "info",
+      message: "Ce commentaire est déjà rejeté.",
+    });
+    return redirectToComments(req, res);
+  }
+  const result = await run(
+    "UPDATE comments SET status='rejected', updated_at=CURRENT_TIMESTAMP WHERE id=?",
+    [comment.id],
+  );
+  if (!result?.changes) {
+    pushNotification(req, {
+      type: "error",
+      message: "Impossible de rejeter ce commentaire.",
+    });
+    return redirectToComments(req, res);
+  }
   comment.status = "rejected";
   pushNotification(req, {
     type: "info",
@@ -261,7 +295,14 @@ async function handleCommentDeletion(req, res) {
     });
     return redirectToComments(req, res);
   }
-  await run("DELETE FROM comments WHERE id=?", [comment.id]);
+  const result = await run("DELETE FROM comments WHERE id=?", [comment.id]);
+  if (!result?.changes) {
+    pushNotification(req, {
+      type: "error",
+      message: "Impossible de supprimer ce commentaire.",
+    });
+    return redirectToComments(req, res);
+  }
   comment.status = "deleted";
   pushNotification(req, {
     type: "success",
@@ -284,20 +325,7 @@ async function fetchModeratableComment(rawId) {
     return { comment: null };
   }
 
-  let whereClause = "c.snowflake_id=?";
-  const params = [identifier];
-  const legacyCandidate = Number.parseInt(identifier, 10);
-  const legacyId =
-    /^[0-9]+$/.test(identifier) && Number.isSafeInteger(legacyCandidate)
-      ? legacyCandidate
-      : null;
-  if (legacyId !== null) {
-    whereClause = "(c.snowflake_id=? OR c.id=?)";
-    params.push(legacyId);
-  }
-
-  const comment = await get(
-    `SELECT c.id,
+  const baseSelect = `SELECT c.id,
             c.snowflake_id,
             c.status,
             c.ip,
@@ -306,10 +334,29 @@ async function fetchModeratableComment(rawId) {
             p.snowflake_id AS page_snowflake_id
        FROM comments c
        JOIN pages p ON p.id = c.page_id
-      WHERE ${whereClause}
-      LIMIT 1`,
-    params,
-  );
+      WHERE %WHERE%
+      LIMIT 1`;
+
+  let comment = null;
+
+  const legacyMatch = identifier.match(/^legacy-(\d+)$/i);
+  const numericIdentifier = legacyMatch
+    ? Number.parseInt(legacyMatch[1], 10)
+    : /^[0-9]+$/.test(identifier)
+      ? Number.parseInt(identifier, 10)
+      : null;
+
+  if (!legacyMatch) {
+    comment = await get(baseSelect.replace("%WHERE%", "c.snowflake_id=?"), [
+      identifier,
+    ]);
+  }
+
+  if (!comment && numericIdentifier !== null && Number.isSafeInteger(numericIdentifier)) {
+    comment = await get(baseSelect.replace("%WHERE%", "c.id=?"), [
+      numericIdentifier,
+    ]);
+  }
 
   if (comment && !comment.snowflake_id) {
     const newSnowflake = generateSnowflake();

--- a/views/admin/comments.ejs
+++ b/views/admin/comments.ejs
@@ -29,7 +29,7 @@
     <p>Aucun commentaire en attente.</p>
   <% } else { %>
     <ul class="admin-comment-list">
-      <% pending.forEach(c => { %>
+      <% pending.forEach(c => { const commentIdentifier = c.snowflake_id ? c.snowflake_id : `legacy-${c.id}`; %>
         <li>
           <header>
             <div>
@@ -44,13 +44,13 @@
             <p class="meta">Dernière modification : <%= new Date(c.updated_at).toLocaleString('fr-FR') %></p>
           <% } %>
           <div class="actions">
-            <form method="post" action="/admin/comments/<%= c.snowflake_id || c.id %>/approve">
+            <form method="post" action="/admin/comments/<%= commentIdentifier %>/approve">
               <button class="btn success" data-icon="✅" type="submit">Approuver</button>
             </form>
-            <form method="post" action="/admin/comments/<%= c.snowflake_id || c.id %>/reject">
+            <form method="post" action="/admin/comments/<%= commentIdentifier %>/reject">
               <button class="btn" data-icon="🚫" type="submit">Rejeter</button>
             </form>
-            <form method="post" action="/admin/comments/<%= c.snowflake_id || c.id %>/delete" onsubmit="return confirm('Supprimer ce commentaire ?');">
+            <form method="post" action="/admin/comments/<%= commentIdentifier %>/delete" onsubmit="return confirm('Supprimer ce commentaire ?');">
               <button class="btn unlike" data-icon="🗑️" type="submit">Supprimer</button>
             </form>
           </div>
@@ -67,7 +67,7 @@
     <p>Aucun commentaire modéré pour le moment.</p>
   <% } else { %>
     <ul class="admin-comment-list compact">
-      <% recent.forEach(c => { %>
+      <% recent.forEach(c => { const commentIdentifier = c.snowflake_id ? c.snowflake_id : `legacy-${c.id}`; %>
         <li>
           <header>
             <div>
@@ -82,7 +82,7 @@
             <p class="meta">Dernière modification : <%= new Date(c.updated_at).toLocaleString('fr-FR') %></p>
           <% } %>
           <div class="actions">
-            <form method="post" action="/admin/comments/<%= c.snowflake_id || c.id %>/delete" onsubmit="return confirm('Supprimer ce commentaire ?');">
+            <form method="post" action="/admin/comments/<%= commentIdentifier %>/delete" onsubmit="return confirm('Supprimer ce commentaire ?');">
               <button class="btn unlike" data-icon="🗑️" type="submit">Supprimer</button>
             </form>
           </div>


### PR DESCRIPTION
## Summary
- ensure admin comment lookups disambiguate between snowflake IDs and numeric legacy identifiers
- prefix legacy comment IDs in moderation forms so each action targets a unique identifier
- prevent admin comment moderation actions from silently succeeding when no change occurs and record the moderation timestamp

## Testing
- Manual curl approval of a pending comment【01767f†L1-L11】

------
https://chatgpt.com/codex/tasks/task_e_68dad20226108321ab7fc74271b4b15f