### PR TITLE
Fix admin comment moderation result handling

### DIFF
--- a/views/admin/comments.ejs
+++ b/views/admin/comments.ejs
@@ -29,7 +29,7 @@
     <p>Aucun commentaire en attente.</p>
   <% } else { %>
     <ul class="admin-comment-list">
-      <% pending.forEach(c => { %>
+      <% pending.forEach(c => { const commentIdentifier = c.snowflake_id ? c.snowflake_id : `legacy-${c.id}`; %>
         <li>
           <header>
             <div>
@@ -44,13 +44,13 @@
             <p class="meta">Dernière modification : <%= new Date(c.updated_at).toLocaleString('fr-FR') %></p>
           <% } %>
           <div class="actions">
-            <form method="post" action="/admin/comments/<%= c.snowflake_id || c.id %>/approve">
+            <form method="post" action="/admin/comments/<%= commentIdentifier %>/approve">
               <button class="btn success" data-icon="✅" type="submit">Approuver</button>
             </form>
-            <form method="post" action="/admin/comments/<%= c.snowflake_id || c.id %>/reject">
+            <form method="post" action="/admin/comments/<%= commentIdentifier %>/reject">
               <button class="btn" data-icon="🚫" type="submit">Rejeter</button>
             </form>
-            <form method="post" action="/admin/comments/<%= c.snowflake_id || c.id %>/delete" onsubmit="return confirm('Supprimer ce commentaire ?');">
+            <form method="post" action="/admin/comments/<%= commentIdentifier %>/delete" onsubmit="return confirm('Supprimer ce commentaire ?');">
               <button class="btn unlike" data-icon="🗑️" type="submit">Supprimer</button>
             </form>
           </div>
@@ -67,7 +67,7 @@
     <p>Aucun commentaire modéré pour le moment.</p>
   <% } else { %>
     <ul class="admin-comment-list compact">
-      <% recent.forEach(c => { %>
+      <% recent.forEach(c => { const commentIdentifier = c.snowflake_id ? c.snowflake_id : `legacy-${c.id}`; %>
         <li>
           <header>
             <div>
@@ -82,7 +82,7 @@
             <p class="meta">Dernière modification : <%= new Date(c.updated_at).toLocaleString('fr-FR') %></p>
           <% } %>
           <div class="actions">
-            <form method="post" action="/admin/comments/<%= c.snowflake_id || c.id %>/delete" onsubmit="return confirm('Supprimer ce commentaire ?');">
+            <form method="post" action="/admin/comments/<%= commentIdentifier %>/delete" onsubmit="return confirm('Supprimer ce commentaire ?');">
               <button class="btn unlike" data-icon="🗑️" type="submit">Supprimer</button>
             </form>
           </div>


### PR DESCRIPTION
## Summary
- ensure admin comment lookups disambiguate between snowflake IDs and numeric legacy identifiers
- prefix legacy comment IDs in moderation forms so each action targets a unique identifier
- prevent admin comment moderation actions from silently succeeding when no change occurs and record the moderation timestamp
- avoid flagging successful moderation updates as failures when the SQLite driver does not report affected rows

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dad20226108321ab7fc74271b4b15f