### PR TITLE
Remove IP profile preference management

### DIFF
--- a/db.js
+++ b/db.js
@@ -83,15 +83,6 @@ export async function initDb() {
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     last_seen_at DATETIME DEFAULT CURRENT_TIMESTAMP
   );
-  CREATE TABLE IF NOT EXISTS ip_profile_preferences(
-    hash TEXT PRIMARY KEY,
-    public_label TEXT,
-    default_author TEXT,
-    comment_page_size INTEGER,
-    compact_comments INTEGER NOT NULL DEFAULT 0,
-    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME
-  );
   CREATE TABLE IF NOT EXISTS page_view_daily(
     page_id INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
     day TEXT NOT NULL,

--- a/public/style.css
+++ b/public/style.css
@@ -1890,26 +1890,6 @@ input[type="checkbox"] {
   font-weight: 600;
 }
 
-.ip-profile-preference-mini ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.45rem;
-}
-
-.ip-profile-preference-mini li {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.6rem;
-}
-
-.ip-profile-preference-mini span {
-  color: var(--muted);
-  font-size: 0.8rem;
-}
-
 .ip-profile-stat {
   position: relative;
 }
@@ -1932,13 +1912,6 @@ input[type="checkbox"] {
   padding: 0;
   display: grid;
   gap: 0.75rem;
-}
-
-.ip-profile-activity.compact li {
-  border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  padding: 0.7rem 0.85rem;
 }
 
 .ip-profile-activity-meta {
@@ -1979,22 +1952,6 @@ input[type="checkbox"] {
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 0.4rem;
-}
-
-.ip-preferences-form {
-  display: grid;
-  gap: 1rem;
-}
-
-.ip-preferences-checkbox {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.form-help {
-  font-size: 0.8rem;
-  color: var(--muted);
 }
 
 .ip-profile-activity-grid .ip-profile-section .text-muted {

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -22,10 +22,8 @@ import { upsertTags, recordRevision } from "../utils/pageEditing.js";
 import { createPageSubmission } from "../utils/pageSubmissionService.js";
 import {
   getIpProfileByHash,
-  getIpProfilePreferencesByIp,
   hashIp,
   touchIpProfile,
-  updateIpProfilePreferences,
   IP_PROFILE_COMMENT_PAGE_SIZES,
 } from "../utils/ipProfiles.js";
 import {
@@ -319,14 +317,11 @@ r.get(
     page.views = Number(page.views || 0) + 1;
     await touchIpProfile(ip);
 
-    const viewerPreferences = await getIpProfilePreferencesByIp(ip);
-    const preferredCommentPageSize = viewerPreferences?.commentPageSize || 10;
-
     const totalComments = Number(page.comment_count || 0);
     const commentPaginationOptions = {
       pageParam: "commentsPage",
       perPageParam: "commentsPerPage",
-      defaultPageSize: preferredCommentPageSize,
+      defaultPageSize: 10,
       pageSizeOptions: [...IP_PROFILE_COMMENT_PAGE_SIZES],
     };
     let commentPagination = buildPagination(
@@ -375,7 +370,6 @@ r.get(
       commentPagination,
       commentFeedback,
       ownCommentTokens,
-      viewerPreferences,
     });
   }),
 );
@@ -1135,51 +1129,7 @@ r.get(
     res.render("ip_profile", {
       profile,
       isOwner: viewerHash ? viewerHash === profile.hash : false,
-      preferenceOptions: {
-        commentPageSizes: IP_PROFILE_COMMENT_PAGE_SIZES,
-      },
     });
-  }),
-);
-
-r.post(
-  "/profiles/ip/:hash/preferences",
-  asyncHandler(async (req, res) => {
-    const requestedHash = (req.params.hash || "").trim().toLowerCase();
-    if (!requestedHash) {
-      return res.status(404).render("page404");
-    }
-
-    const viewerHash = hashIp(req.clientIp);
-    if (!viewerHash || viewerHash !== requestedHash) {
-      pushNotification(req, {
-        type: "error",
-        message: "Vous ne pouvez modifier que vos propres préférences.",
-      });
-      return res.redirect(`/profiles/ip/${requestedHash}`);
-    }
-
-    try {
-      await updateIpProfilePreferences(requestedHash, {
-        publicLabel: req.body.publicLabel,
-        defaultAuthor: req.body.defaultAuthor,
-        commentPageSize: req.body.commentPageSize,
-        compactComments: req.body.compactComments === "on",
-      });
-      pushNotification(req, {
-        type: "success",
-        message: "Préférences mises à jour.",
-      });
-    } catch (err) {
-      console.error("Unable to update IP profile preferences", err);
-      pushNotification(req, {
-        type: "error",
-        message:
-          "Impossible d'enregistrer vos préférences pour le moment. Merci de réessayer.",
-      });
-    }
-
-    res.redirect(`/profiles/ip/${requestedHash}#preferences`);
   }),
 );
 

--- a/utils/ipProfiles.js
+++ b/utils/ipProfiles.js
@@ -28,62 +28,7 @@ const IP_REPUTATION_TIMEOUT_MS = Number.isFinite(configuredTimeout)
   : DEFAULT_TIMEOUT_MS;
 
 const SALT = process.env.IP_PROFILE_SALT || "simple-wiki-ip-profile::v1";
-const COMMENT_PAGE_SIZE_OPTIONS = [5, 10, 20, 50];
-export const IP_PROFILE_COMMENT_PAGE_SIZES = Object.freeze([
-  ...COMMENT_PAGE_SIZE_OPTIONS,
-]);
-
-function normalizePublicLabel(value) {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-  return trimmed.slice(0, 60);
-}
-
-function normalizeDefaultAuthor(value) {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-  return trimmed.slice(0, 80);
-}
-
-function normalizeCommentPageSize(value) {
-  if (value === undefined || value === null || value === "") {
-    return null;
-  }
-  const numeric = Number.parseInt(value, 10);
-  if (!Number.isInteger(numeric)) {
-    return null;
-  }
-  return COMMENT_PAGE_SIZE_OPTIONS.includes(numeric) ? numeric : null;
-}
-
-function mapPreferenceRow(row) {
-  if (!row) {
-    return {
-      publicLabel: null,
-      defaultAuthor: null,
-      commentPageSize: null,
-      compactComments: false,
-      updatedAt: null,
-    };
-  }
-  return {
-    publicLabel: row.public_label ? row.public_label : null,
-    defaultAuthor: row.default_author ? row.default_author : null,
-    commentPageSize: normalizeCommentPageSize(row.comment_page_size),
-    compactComments: Boolean(row.compact_comments),
-    updatedAt: row.updated_at || row.created_at || null,
-  };
-}
+export const IP_PROFILE_COMMENT_PAGE_SIZES = Object.freeze([5, 10, 20, 50]);
 
 function normalizeOverride(value) {
   if (!value) {
@@ -392,7 +337,6 @@ export async function getIpProfileByHash(hash) {
     recentViews,
     recentSubmissions,
     activeBans,
-    preferencesRow,
   ] =
     await Promise.all([
       get(
@@ -464,13 +408,6 @@ export async function getIpProfileByHash(hash) {
         [profile.ip],
       ),
       getActiveBans(profile.ip),
-      get(
-        `SELECT public_label, default_author, comment_page_size, compact_comments,
-                created_at, updated_at
-           FROM ip_profile_preferences
-          WHERE hash = ?`,
-        [profile.hash],
-      ),
     ]);
 
   const submissionsByStatus = submissionBreakdown.reduce(
@@ -560,73 +497,7 @@ export async function getIpProfileByHash(hash) {
           createdAt: ban.created_at,
         }))
       : [],
-    preferences: mapPreferenceRow(preferencesRow),
   };
-}
-
-export async function getIpProfilePreferences(hash) {
-  const normalized = normalizeIp(hash);
-  if (!normalized) {
-    return mapPreferenceRow(null);
-  }
-  const row = await get(
-    `SELECT public_label, default_author, comment_page_size, compact_comments,
-            created_at, updated_at
-       FROM ip_profile_preferences
-      WHERE hash = ?`,
-    [normalized],
-  );
-  return mapPreferenceRow(row);
-}
-
-export async function getIpProfilePreferencesByIp(ip) {
-  const hashed = hashIp(ip);
-  if (!hashed) {
-    return mapPreferenceRow(null);
-  }
-  return getIpProfilePreferences(hashed);
-}
-
-export async function updateIpProfilePreferences(
-  hash,
-  { publicLabel, defaultAuthor, commentPageSize, compactComments } = {},
-) {
-  const normalized = normalizeIp(hash);
-  if (!normalized) {
-    throw new Error("Profil IP introuvable");
-  }
-
-  const normalizedLabel = normalizePublicLabel(publicLabel);
-  const normalizedAuthor = normalizeDefaultAuthor(defaultAuthor);
-  const normalizedPageSize = normalizeCommentPageSize(commentPageSize);
-  const compactFlag = compactComments ? 1 : 0;
-
-  await run(
-    `INSERT INTO ip_profile_preferences(
-        hash,
-        public_label,
-        default_author,
-        comment_page_size,
-        compact_comments,
-        updated_at
-      )
-      VALUES(?,?,?,?,?,CURRENT_TIMESTAMP)
-      ON CONFLICT(hash) DO UPDATE SET
-        public_label=excluded.public_label,
-        default_author=excluded.default_author,
-        comment_page_size=excluded.comment_page_size,
-        compact_comments=excluded.compact_comments,
-        updated_at=CURRENT_TIMESTAMP`,
-    [
-      normalized,
-      normalizedLabel,
-      normalizedAuthor,
-      normalizedPageSize,
-      compactFlag,
-    ],
-  );
-
-  return getIpProfilePreferences(normalized);
 }
 
 export async function countIpProfiles({ search = null } = {}) {

--- a/views/ip_profile.ejs
+++ b/views/ip_profile.ejs
@@ -1,6 +1,4 @@
-<% const preferences = profile.preferences || {}; %>
-<% const customLabel = preferences.publicLabel && preferences.publicLabel.trim() ? preferences.publicLabel.trim() : null; %>
-<% const displayTitle = customLabel || `Profil IP #${profile.shortHash}`; %>
+<% const displayTitle = `Profil IP #${profile.shortHash}`; %>
 <% title = displayTitle; %>
 <% const rep = profile.reputation || {}; %>
 <% const repStatus = rep.status || 'unknown'; %>
@@ -8,12 +6,7 @@
 <% let repClasses = 'ip-profile-reputation card-subtle notice'; %>
 <% if (repStatus === 'suspicious') { repClasses += ' error'; } else if (repStatus === 'safe' || repStatus === 'clean') { repClasses += ' success'; } %>
 <% const pillClass = repStatus === 'suspicious' ? 'status-pill suspicious' : repStatus === 'safe' ? 'status-pill safe' : repStatus === 'clean' ? 'status-pill clean' : 'status-pill pending'; %>
-<% const pageSizeOptions = Array.isArray(preferenceOptions?.commentPageSizes) && preferenceOptions.commentPageSizes.length ? preferenceOptions.commentPageSizes : [5, 10, 20, 50]; %>
-<% const activityListClass = ['ip-profile-activity']; %>
-<% if (preferences.compactComments) { activityListClass.push('compact'); } %>
-<% const activityClassName = activityListClass.join(' '); %>
-<% const defaultAuthorLabel = preferences.defaultAuthor ? preferences.defaultAuthor : 'Non défini'; %>
-<% const commentPageSizeLabel = preferences.commentPageSize || 10; %>
+<% const activityClassName = 'ip-profile-activity'; %>
 
 <section class="card ip-profile-card">
   <header class="ip-profile-header">
@@ -29,7 +22,6 @@
         <p class="ip-profile-owner-note">
           Vous consultez votre propre profil IP. Seules les contributions publiques (commentaires approuvés, likes, vues et propositions) sont visibles ici.
         </p>
-        <a class="btn secondary btn-compact" href="#preferences" data-icon="⚙️">Modifier mes préférences</a>
       </div>
     <% } %>
   </header>
@@ -61,19 +53,6 @@
           <dd><code>#<%= profile.shortHash %></code></dd>
         </div>
       </dl>
-      <% if (isOwner) { %>
-        <div class="ip-profile-preference-mini">
-          <h3>Préférences rapides</h3>
-          <ul>
-            <li><span>Nom public</span><strong><%= customLabel || `Profil IP #${profile.shortHash}` %></strong></li>
-            <li><span>Nom par défaut</span><strong><%= defaultAuthorLabel %></strong></li>
-            <li><span>Commentaires/page</span><strong><%= commentPageSizeLabel %></strong></li>
-          </ul>
-          <% if (preferences.updatedAt) { %>
-            <p class="text-sm text-muted">Mis à jour le <%= new Date(preferences.updatedAt).toLocaleString('fr-FR') %></p>
-          <% } %>
-        </div>
-      <% } %>
     </div>
   </div>
 
@@ -184,52 +163,6 @@
           </li>
         <% }) %>
       </ul>
-    </section>
-  <% } %>
-
-  <% if (isOwner) { %>
-    <section id="preferences" class="ip-profile-section card-subtle ip-profile-preferences">
-      <h2>Mes préférences</h2>
-      <p class="text-muted">
-        Personnalisez l'apparence de votre profil et les paramètres par défaut utilisés lors de vos contributions.
-      </p>
-      <form method="post" action="/profiles/ip/<%= profile.hash %>/preferences" class="ip-preferences-form">
-        <label class="stack-form">
-          <span class="text-sm text-muted">Nom public du profil</span>
-          <input
-            type="text"
-            name="publicLabel"
-            maxlength="60"
-            value="<%= customLabel || '' %>"
-            placeholder="Profil IP personnalisé"
-          />
-          <span class="form-help">Laissez vide pour afficher « Profil IP #<%= profile.shortHash %> ».</span>
-        </label>
-        <label class="stack-form">
-          <span class="text-sm text-muted">Nom par défaut pour vos commentaires</span>
-          <input
-            type="text"
-            name="defaultAuthor"
-            maxlength="80"
-            value="<%= preferences.defaultAuthor || '' %>"
-            placeholder="Anonyme"
-          />
-        </label>
-        <label class="stack-form">
-          <span class="text-sm text-muted">Commentaires affichés par page</span>
-          <select name="commentPageSize">
-            <option value="" <%= preferences.commentPageSize ? '' : 'selected' %>>Automatique (10)</option>
-            <% pageSizeOptions.forEach((size) => { %>
-              <option value="<%= size %>" <%= preferences.commentPageSize === size ? 'selected' : '' %>><%= size %></option>
-            <% }) %>
-          </select>
-        </label>
-        <label class="checkbox ip-preferences-checkbox">
-          <input type="checkbox" name="compactComments" <%= preferences.compactComments ? 'checked' : '' %> />
-          <span>Afficher les historiques en mode compact</span>
-        </label>
-        <button class="btn success" data-icon="💾" type="submit">Enregistrer</button>
-      </form>
     </section>
   <% } %>
 

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -58,9 +58,7 @@
   ? (commentUser.display_name || commentUser.username)
   : null; %>
 <% const commentValues = (commentFeedback && commentFeedback.values) || {}; %>
-<% const viewerPrefs = typeof viewerPreferences !== 'undefined' ? viewerPreferences : null; %>
-<% const savedDefaultAuthor = viewerPrefs && viewerPrefs.defaultAuthor ? viewerPrefs.defaultAuthor : ''; %>
-<% const commentAuthorValue = adminPreferredName || commentValues.author || savedDefaultAuthor; %>
+<% const commentAuthorValue = adminPreferredName || commentValues.author || ''; %>
 <section class="card comments" id="comments">
   <h2 class="mt-0">Commentaires</h2>
   <% if (comments && comments.length) { %>


### PR DESCRIPTION
## Summary
- remove the IP profile preference UI, styling, and update endpoint
- simplify comment defaults and pagination so they no longer depend on stored IP preferences
- drop the unused IP profile preference schema and related helper code

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68dade72d79c8321b26ab7386b574c0f