### PR TITLE
Add account submissions page for contributors

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ import { initDb } from "./db.js";
 import { sessionConfig } from "./utils/config.js";
 import authRoutes from "./routes/auth.js";
 import adminRoutes from "./routes/admin.js";
+import accountRoutes from "./routes/account.js";
 import pagesRoutes from "./routes/pages.js";
 import searchRoutes from "./routes/search.js";
 import { getSiteSettings } from "./utils/settingsService.js";
@@ -122,6 +123,7 @@ app.get("/rss.xml", async (req, res) => {
 
 app.use("/", pagesRoutes);
 app.use("/", authRoutes);
+app.use("/account", accountRoutes);
 app.use("/admin", adminRoutes);
 app.use("/", searchRoutes);
 

--- a/public/app.js
+++ b/public/app.js
@@ -131,7 +131,22 @@ function spawnNotification(layer, notif) {
 
   const message = document.createElement("div");
   message.className = "notification-message";
-  message.textContent = notif.message;
+  const messageText = document.createElement("span");
+  messageText.textContent = notif.message;
+  message.appendChild(messageText);
+
+  if (notif.action && typeof notif.action.href === "string") {
+    const actionLink = document.createElement("a");
+    actionLink.className = "notification-action";
+    actionLink.href = notif.action.href;
+    actionLink.textContent =
+      typeof notif.action.label === "string" && notif.action.label
+        ? notif.action.label
+        : "Ouvrir";
+    actionLink.rel = "noopener";
+    message.appendChild(actionLink);
+  }
+
   body.appendChild(message);
 
   item.appendChild(body);

--- a/public/style.css
+++ b/public/style.css
@@ -1419,6 +1419,21 @@ input[type="checkbox"] {
   color: var(--muted);
 }
 
+.notification-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.4rem;
+  font-weight: 500;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.notification-action::after {
+  content: "→";
+  font-size: 0.85em;
+}
+
 .notification-close {
   margin-left: auto;
   background: transparent;

--- a/routes/account.js
+++ b/routes/account.js
@@ -1,0 +1,93 @@
+import { Router } from "express";
+import { asyncHandler } from "../utils/asyncHandler.js";
+import {
+  countPageSubmissions,
+  fetchPageSubmissions,
+  mapSubmissionTags,
+} from "../utils/pageSubmissionService.js";
+import { buildPaginationView } from "../utils/pagination.js";
+import { getClientIp } from "../utils/ip.js";
+
+const r = Router();
+
+r.use((req, res, next) => {
+  if (!req.session.user) {
+    return res.redirect("/login");
+  }
+  next();
+});
+
+function resolveIdentity(req) {
+  return {
+    submittedBy: req.session.user?.username || null,
+    ip: getClientIp(req) || null,
+  };
+}
+
+async function buildSection(req, identity, { status, pageParam, perPageParam, orderBy, direction }) {
+  const total = await countPageSubmissions({
+    status,
+    submittedBy: identity.submittedBy,
+    ip: identity.ip,
+  });
+  const pagination = buildPaginationView(req, total, { pageParam, perPageParam });
+  let rows = [];
+  if (total > 0) {
+    const offset = (pagination.page - 1) * pagination.perPage;
+    const fetched = await fetchPageSubmissions({
+      status,
+      limit: pagination.perPage,
+      offset,
+      orderBy,
+      direction,
+      submittedBy: identity.submittedBy,
+      ip: identity.ip,
+    });
+    rows = fetched.map((item) => ({
+      ...item,
+      tag_list: mapSubmissionTags(item),
+    }));
+  }
+  return { rows, pagination };
+}
+
+r.get(
+  "/submissions",
+  asyncHandler(async (req, res) => {
+    const identity = resolveIdentity(req);
+    const [pending, approved, rejected] = await Promise.all([
+      buildSection(req, identity, {
+        status: "pending",
+        pageParam: "pendingPage",
+        perPageParam: "pendingPerPage",
+        orderBy: "created_at",
+        direction: "DESC",
+      }),
+      buildSection(req, identity, {
+        status: "approved",
+        pageParam: "approvedPage",
+        perPageParam: "approvedPerPage",
+        orderBy: "reviewed_at",
+        direction: "DESC",
+      }),
+      buildSection(req, identity, {
+        status: "rejected",
+        pageParam: "rejectedPage",
+        perPageParam: "rejectedPerPage",
+        orderBy: "reviewed_at",
+        direction: "DESC",
+      }),
+    ]);
+
+    res.render("account/submissions", {
+      pending: pending.rows,
+      approved: approved.rows,
+      rejected: rejected.rows,
+      pendingPagination: pending.pagination,
+      approvedPagination: approved.pagination,
+      rejectedPagination: rejected.pagination,
+    });
+  }),
+);
+
+export default r;

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -246,8 +246,13 @@ r.post(
       await touchIpProfile(req.clientIp);
       pushNotification(req, {
         type: "success",
-        message: "Merci ! Votre proposition sera examinée par un administrateur.",
+        message:
+          "Merci ! Votre proposition sera examinée par un administrateur.",
         timeout: 6000,
+        action: {
+          href: "/account/submissions",
+          label: "Suivre mes contributions",
+        },
       });
       await sendAdminEvent("Soumission de nouvelle page", {
         page: { title },
@@ -818,6 +823,10 @@ r.post(
         message:
           "Merci ! Votre proposition de mise à jour sera vérifiée avant publication.",
         timeout: 6000,
+        action: {
+          href: "/account/submissions",
+          label: "Suivre mes contributions",
+        },
       });
       await sendAdminEvent("Soumission de modification", {
         page: {

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -2,7 +2,25 @@ import { randomUUID } from "crypto";
 
 const DEFAULT_TIMEOUT = 5000;
 
-export function pushNotification(req, { type = "info", message, timeout = DEFAULT_TIMEOUT } = {}) {
+function normalizeAction(action) {
+  if (!action || typeof action !== "object") {
+    return null;
+  }
+  const href = typeof action.href === "string" && action.href.trim() ? action.href.trim() : null;
+  if (!href) {
+    return null;
+  }
+  const label =
+    typeof action.label === "string" && action.label.trim()
+      ? action.label.trim()
+      : null;
+  return { href, label };
+}
+
+export function pushNotification(
+  req,
+  { type = "info", message, timeout = DEFAULT_TIMEOUT, action = null } = {},
+) {
   if (!req?.session || !message) {
     return;
   }
@@ -14,6 +32,7 @@ export function pushNotification(req, { type = "info", message, timeout = DEFAUL
     type,
     message,
     timeout: Number.isFinite(timeout) ? timeout : DEFAULT_TIMEOUT,
+    action: normalizeAction(action),
   });
 }
 

--- a/views/account/submissions.ejs
+++ b/views/account/submissions.ejs
@@ -1,0 +1,143 @@
+<% title = 'Mes contributions'; %>
+<h1>Mes contributions</h1>
+<p class="text-muted mb-lg">
+  Retrouvez ici l’ensemble de vos propositions de pages ou de modifications. Vous pouvez suivre
+  leur traitement par l’équipe de modération.
+</p>
+
+<section class="card mb-xl">
+  <h2>En attente (<%= pendingPagination.totalItems %>)</h2>
+  <% if (!pending.length) { %>
+    <p>Aucune contribution en attente de validation pour le moment.</p>
+  <% } else { %>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Type</th>
+            <th>Titre proposé</th>
+            <th>Page liée</th>
+            <th>Tags</th>
+            <th>Soumise le</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% pending.forEach(item => { %>
+            <tr>
+              <td><code><%= item.snowflake_id %></code></td>
+              <td><%= item.type === 'edit' ? 'Modification' : 'Création' %></td>
+              <td><strong><%= item.title %></strong></td>
+              <td>
+                <% if (item.current_slug) { %>
+                  <a href="/wiki/<%= item.current_slug %>"><code><%= item.current_slug %></code></a>
+                <% } else { %>
+                  –
+                <% } %>
+              </td>
+              <td>
+                <% if (item.tag_list && item.tag_list.length) { %>
+                  <%= item.tag_list.join(', ') %>
+                <% } else { %>
+                  –
+                <% } %>
+              </td>
+              <td><%= new Date(item.created_at).toLocaleString('fr-FR') %></td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+    <%- include('../admin/paginationControls', { pagination: pendingPagination }) %>
+  <% } %>
+</section>
+
+<section class="card mb-xl">
+  <h2>Approuvées (<%= approvedPagination.totalItems %>)</h2>
+  <% if (!approved.length) { %>
+    <p>Vous n’avez pas encore de contribution approuvée.</p>
+  <% } else { %>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Type</th>
+            <th>Titre proposé</th>
+            <th>Publié le</th>
+            <th>Page finale</th>
+            <th>Note du modérateur</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% approved.forEach(item => { %>
+            <tr>
+              <td><code><%= item.snowflake_id %></code></td>
+              <td><%= item.type === 'edit' ? 'Modification' : 'Création' %></td>
+              <td><strong><%= item.title %></strong></td>
+              <td>
+                <% if (item.reviewed_at) { %>
+                  <%= new Date(item.reviewed_at).toLocaleString('fr-FR') %>
+                <% } else { %>
+                  –
+                <% } %>
+              </td>
+              <td>
+                <% if (item.result_slug_id) { %>
+                  <a href="/wiki/<%= item.result_slug_id %>"><code><%= item.result_slug_id %></code></a>
+                <% } else if (item.target_slug_id) { %>
+                  <a href="/wiki/<%= item.target_slug_id %>"><code><%= item.target_slug_id %></code></a>
+                <% } else if (item.current_slug) { %>
+                  <a href="/wiki/<%= item.current_slug %>"><code><%= item.current_slug %></code></a>
+                <% } else { %>
+                  –
+                <% } %>
+              </td>
+              <td><%= item.review_note ? item.review_note : '–' %></td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+    <%- include('../admin/paginationControls', { pagination: approvedPagination }) %>
+  <% } %>
+</section>
+
+<section class="card">
+  <h2>Rejetées (<%= rejectedPagination.totalItems %>)</h2>
+  <% if (!rejected.length) { %>
+    <p>Aucune contribution rejetée n’a été trouvée.</p>
+  <% } else { %>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Type</th>
+            <th>Titre proposé</th>
+            <th>Décision</th>
+            <th>Raison</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% rejected.forEach(item => { %>
+            <tr>
+              <td><code><%= item.snowflake_id %></code></td>
+              <td><%= item.type === 'edit' ? 'Modification' : 'Création' %></td>
+              <td><strong><%= item.title %></strong></td>
+              <td>
+                <% if (item.reviewed_at) { %>
+                  <%= new Date(item.reviewed_at).toLocaleString('fr-FR') %>
+                <% } else { %>
+                  –
+                <% } %>
+              </td>
+              <td><%= item.review_note ? item.review_note : '–' %></td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+    <%- include('../admin/paginationControls', { pagination: rejectedPagination }) %>
+  <% } %>
+</section>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -56,6 +56,9 @@
       <% if (!currentUser || !currentUser.is_admin) { %>
         <a href="/new">✍️ Contribuer</a>
       <% } %>
+      <% if (currentUser) { %>
+        <a href="/account/submissions">🗂️ Mes contributions</a>
+      <% } %>
       <% if (currentUser && currentUser.is_admin) { %>
         <% const adminCounts = typeof adminActionCounts !== 'undefined' ? adminActionCounts : {}; %>
         <a href="/new">➕ Nouvelle page</a>


### PR DESCRIPTION
## Summary
- add a protected /account/submissions route and EJS view to list a user’s pending, approved, and rejected submissions with pagination
- extend the page submission service to support filtering by submitter identity (username or IP) and surface the new page in the navigation and submission notifications
- enhance notifications to support action links so contributors can jump directly to their submission history

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dae940c5cc8321907dbaf767fa5506