### PR TITLE
Update follow-up notification link to IP profile for anonymous submissions

### DIFF
--- a/routes/pages.js
+++ b/routes/pages.js
@@ -244,15 +244,15 @@ r.post(
         submittedBy: req.session.user?.username || null,
       });
       await touchIpProfile(req.clientIp);
+      const followAction = req.session.user
+        ? { href: "/account/submissions", label: "Suivre mes contributions" }
+        : { href: "/profiles/ip/me", label: "Suivre mes contributions" };
       pushNotification(req, {
         type: "success",
         message:
           "Merci ! Votre proposition sera examinée par un administrateur.",
         timeout: 6000,
-        action: {
-          href: "/account/submissions",
-          label: "Suivre mes contributions",
-        },
+        action: followAction,
       });
       await sendAdminEvent("Soumission de nouvelle page", {
         page: { title },
@@ -818,15 +818,15 @@ r.post(
         targetSlugId: page.slug_id,
       });
       await touchIpProfile(req.clientIp);
+      const followAction = req.session.user
+        ? { href: "/account/submissions", label: "Suivre mes contributions" }
+        : { href: "/profiles/ip/me", label: "Suivre mes contributions" };
       pushNotification(req, {
         type: "success",
         message:
           "Merci ! Votre proposition de mise à jour sera vérifiée avant publication.",
         timeout: 6000,
-        action: {
-          href: "/account/submissions",
-          label: "Suivre mes contributions",
-        },
+        action: followAction,
       });
       await sendAdminEvent("Soumission de modification", {
         page: {


### PR DESCRIPTION
## Summary
- update the submission follow-up notification to link logged-in users to their contribution dashboard
- direct anonymous contributors to their public IP profile so they can review activity without logging in

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daeb73dbec83219c8ae6412aee3221