### PR TITLE
Allow guests to review their submissions

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -10,13 +10,6 @@ import { getClientIp } from "../utils/ip.js";
 
 const r = Router();
 
-r.use((req, res, next) => {
-  if (!req.session.user) {
-    return res.redirect("/login");
-  }
-  next();
-});
-
 function resolveIdentity(req) {
   return {
     submittedBy: req.session.user?.username || null,
@@ -25,6 +18,15 @@ function resolveIdentity(req) {
 }
 
 async function buildSection(req, identity, { status, pageParam, perPageParam, orderBy, direction }) {
+  const hasIdentity = Boolean(identity.submittedBy) || Boolean(identity.ip);
+
+  if (!hasIdentity) {
+    return {
+      rows: [],
+      pagination: buildPaginationView(req, 0, { pageParam, perPageParam }),
+    };
+  }
+
   const total = await countPageSubmissions({
     status,
     submittedBy: identity.submittedBy,

--- a/views/account/submissions.ejs
+++ b/views/account/submissions.ejs
@@ -4,6 +4,12 @@
   Retrouvez ici l’ensemble de vos propositions de pages ou de modifications. Vous pouvez suivre
   leur traitement par l’équipe de modération.
 </p>
+<% if (!user) { %>
+  <p class="alert alert-info">
+    Vous n’êtes pas connecté. Nous affichons ici les contributions envoyées depuis cette adresse
+    IP. Connectez-vous ou créez un compte pour associer vos futures contributions à votre profil.
+  </p>
+<% } %>
 
 <section class="card mb-xl">
   <h2>En attente (<%= pendingPagination.totalItems %>)</h2>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -101,9 +101,7 @@
       <% if (!currentUser || !currentUser.is_admin) { %>
         <a href="/new">✍️ Contribuer</a>
       <% } %>
-      <% if (currentUser) { %>
-        <a href="/account/submissions">🗂️ Mes contributions</a>
-      <% } %>
+      <a href="/account/submissions">🗂️ Mes contributions</a>
       <% if (currentUser && currentUser.is_admin) { %>
         <% const adminCounts = typeof adminActionCounts !== 'undefined' ? adminActionCounts : {}; %>
         <a href="/new">➕ Nouvelle page</a>


### PR DESCRIPTION
## Summary
- allow the account submissions route to work for unauthenticated visitors by guarding the identity filters instead of forcing a login
- surface an informational message explaining how guest submissions are matched and expose the navigation link to everyone

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dafd258bbc83219494dc1af9032703