### PR TITLE
Fix mobile zoom triggered when tapping buttons

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -623,7 +623,8 @@ html.drawer-open .drawer-overlay {
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.04);
   color: inherit;
-  font-size: 0.95rem;
+  /* Keep touch targets at >= 16px font size to avoid iOS zooming on tap */
+  font-size: 1rem;
   line-height: 1.2;
   font-weight: 500;
   cursor: pointer;
@@ -1655,6 +1656,13 @@ input[type="checkbox"] {
   font-size: 0.85rem;
   gap: 0.3rem;
   box-shadow: 0 8px 18px rgba(9, 12, 20, 0.22);
+}
+
+@media (pointer: coarse) {
+  /* Prevent zooming on smaller compact buttons when tapped on touch devices */
+  .btn-compact {
+    font-size: 1rem;
+  }
 }
 
 .admin-risk-list {


### PR DESCRIPTION
## Summary
- set the base button style to use a 16px font size to prevent iOS zooming when tapped
- raise compact button font sizes on touch devices to keep interactions consistent without zooming

## Testing
- npm test *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68db561da22c8321b7169c2d8bac46c2