### PR TITLE
Fix mobile button shift on home articles

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -664,6 +664,19 @@ html.drawer-open .drawer-overlay {
   transform: scale(0.97);
 }
 
+@media (hover: none) and (pointer: coarse) {
+  .btn {
+    transition:
+      background var(--transition),
+      border-color var(--transition),
+      color var(--transition);
+  }
+
+  .btn:active {
+    transform: none;
+  }
+}
+
 .btn::after {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Summary
- prevent mobile button taps from scaling the buttons and pushing the action row downward
- scope the change to coarse pointer devices so desktop hover effects remain intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db89f37cb48321b2620ce88c4a8e83