### PR TITLE
Prevent home article cards from expanding on button clicks

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -630,6 +630,7 @@ html.drawer-open .drawer-overlay {
   cursor: pointer;
   position: relative;
   overflow: hidden;
+  white-space: nowrap;
   transition:
     transform 180ms ease,
     box-shadow 220ms ease,


### PR DESCRIPTION
## Summary
- keep home page buttons on a single line so the cards do not expand vertically when clicked

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db8cee32a883219bc7113a87c2d6e3