### PR TITLE
Improve mobile layout for home article card buttons

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -607,6 +607,10 @@ html.drawer-open .drawer-overlay {
     text-align: center;
   }
 
+  .card-actions form {
+    flex: 1 1 100%;
+  }
+
   .card-actions .btn {
     flex: 1 1 100%;
   }
@@ -630,6 +634,7 @@ html.drawer-open .drawer-overlay {
   cursor: pointer;
   position: relative;
   overflow: hidden;
+  white-space: nowrap;
   transition:
     transform 180ms ease,
     box-shadow 220ms ease,
@@ -985,10 +990,19 @@ html.drawer-open .drawer-overlay {
 
 .card-actions form {
   margin: 0;
+  display: flex;
+  flex: 1 1 150px;
+  min-width: 0;
+}
+
+.card-actions form .btn {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .card-actions .btn {
   flex: 1 1 150px;
+  min-width: 0;
 }
 
 .card-empty {


### PR DESCRIPTION
## Summary
- make the like form in home article cards flex so the button can shrink without stretching the card
- allow both anchors and forms in the card action row to shrink on narrow screens while keeping full-width stacking on mobile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db8cee32a883219bc7113a87c2d6e3