### PR TITLE
Prevent card expansion on touch devices

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1137,6 +1137,15 @@ html.drawer-open .drawer-overlay {
   background: linear-gradient(150deg, rgba(36, 46, 102, 0.82), rgba(15, 20, 46, 0.92));
 }
 
+@media (hover: none) and (pointer: coarse) {
+  .card:focus-within {
+    transform: none;
+    border-color: rgba(162, 176, 255, 0.16);
+    box-shadow: 0 24px 48px rgba(7, 10, 30, 0.42);
+    background: linear-gradient(160deg, rgba(22, 29, 64, 0.78), rgba(13, 18, 36, 0.82));
+  }
+}
+
 .card.card-highlight {
   background: linear-gradient(135deg, rgba(122, 92, 255, 0.28), rgba(72, 196, 255, 0.22));
   border-color: rgba(136, 180, 255, 0.52);


### PR DESCRIPTION
## Summary
- stop applying the hover/focus transform on cards for coarse pointer devices so mobile taps no longer expand the article tile repeatedly

## Testing
- not run (CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbda539fa08321b2bde4892c694dfa