### PR TITLE
Adjust card focus interactions

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1129,12 +1129,27 @@ html.drawer-open .drawer-overlay {
   margin-top: 1.25rem;
 }
 
-.card:hover,
-.card:focus-within {
+.card:hover {
   transform: translateY(-6px) scale(1.01);
   border-color: rgba(182, 198, 255, 0.5);
   box-shadow: 0 32px 60px rgba(12, 18, 48, 0.45);
   background: linear-gradient(150deg, rgba(36, 46, 102, 0.82), rgba(15, 20, 46, 0.92));
+}
+
+.card:focus-within {
+  transform: none;
+  border-color: rgba(182, 198, 255, 0.5);
+  box-shadow: 0 32px 60px rgba(12, 18, 48, 0.45);
+  background: linear-gradient(150deg, rgba(36, 46, 102, 0.82), rgba(15, 20, 46, 0.92));
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .card:focus-within {
+    transform: none;
+    border-color: rgba(182, 198, 255, 0.5);
+    box-shadow: 0 0 0 2px rgba(122, 92, 255, 0.35);
+    background: linear-gradient(150deg, rgba(36, 46, 102, 0.82), rgba(15, 20, 46, 0.92));
+  }
 }
 
 .card.card-highlight {


### PR DESCRIPTION
## Summary
- split the combined card hover/focus rule so hover keeps the animated transform while focus remains static
- update the focus-within styling to provide a highlight without movement
- add a coarse pointer media query so touch interactions keep the card stationary

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbec5252e483219b960b865142f616