### PR TITLE
Prevent focus shift on touch devices

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -898,6 +898,11 @@ html.drawer-open .drawer-overlay {
       color var(--transition);
   }
 
+  .btn:focus-visible {
+    transform: none;
+    box-shadow: 0 24px 44px rgba(10, 16, 40, 0.4);
+  }
+
   .btn:active {
     transform: none;
   }


### PR DESCRIPTION
## Summary
- disable the focus-induced transform for buttons on coarse pointer devices
- keep the elevated focus shadow so buttons retain visual feedback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbf387cb2c8321be2c16ef91b3b03f