### PR TITLE
Ensure notifications close on demand

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -159,11 +159,25 @@ function spawnNotification(layer, notif) {
   close.textContent = "✕";
   item.appendChild(close);
 
+  let removing = false;
   const remove = () => {
+    if (removing || !item.isConnected) {
+      return;
+    }
+
+    removing = true;
     item.classList.remove("show");
+
+    const fallback = setTimeout(() => {
+      if (item.isConnected) {
+        item.remove();
+      }
+    }, 300);
+
     item.addEventListener(
       "transitionend",
       () => {
+        clearTimeout(fallback);
         item.remove();
       },
       { once: true },

--- a/public/style.css
+++ b/public/style.css
@@ -463,6 +463,14 @@ textarea {
   display: flex;
   align-items: flex-start;
   gap: 0.75rem;
+  opacity: 0;
+  transform: translateY(-8px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.notification.show {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .notification.info {


### PR DESCRIPTION
## Summary
- add fade/slide animation for notifications so the close button triggers a transition
- guard the notification removal logic with a fallback timeout to ensure the element is removed even without a transition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1bfb1ea083219f169545b246e87b