### PR TITLE
Add dual-mode chatbot for wiki knowledge base

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ import adminRoutes from "./routes/admin.js";
 import accountRoutes from "./routes/account.js";
 import pagesRoutes from "./routes/pages.js";
 import searchRoutes from "./routes/search.js";
+import chatbotRoutes from "./routes/chatbot.js";
 import { getSiteSettings } from "./utils/settingsService.js";
 import { consumeNotifications } from "./utils/notifications.js";
 import { getClientIp, getClientUserAgent } from "./utils/ip.js";
@@ -31,6 +32,8 @@ app.set("layout", "layout");
 
 // Allow larger rich-text form submissions (e.g. with embedded images).
 const urlencodedBodyLimit = process.env.URLENCODED_BODY_LIMIT || "10mb";
+const jsonBodyLimit = process.env.JSON_BODY_LIMIT || "2mb";
+app.use(express.json({ limit: jsonBodyLimit }));
 app.use(express.urlencoded({ extended: true, limit: urlencodedBodyLimit }));
 app.use(methodOverride("_method"));
 app.use(morgan("dev"));
@@ -127,6 +130,7 @@ app.use("/", authRoutes);
 app.use("/account", accountRoutes);
 app.use("/admin", adminRoutes);
 app.use("/", searchRoutes);
+app.use("/", chatbotRoutes);
 
 app.use((err, req, res, next) => {
   console.error(err);

--- a/public/chatbot.js
+++ b/public/chatbot.js
@@ -1,0 +1,139 @@
+function initChatbot() {
+  const form = document.querySelector("[data-chatbot-form]");
+  if (!form) {
+    return;
+  }
+
+  const textarea = form.querySelector("textarea[name='message']");
+  const variantSelect = form.querySelector("select[name='variant']");
+  const messagesContainer = document.querySelector("[data-chatbot-messages]");
+  const emptyState = document.querySelector("[data-chatbot-empty]");
+  const submitButton = form.querySelector("button[type='submit']");
+  const chatbotSection = document.querySelector(".chatbot");
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!textarea) {
+      return;
+    }
+
+    const message = textarea.value.trim();
+    if (!message) {
+      textarea.focus();
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const payload = {
+        message,
+        variant: variantSelect ? variantSelect.value : "public",
+      };
+      const response = await fetch("/chatbot/query", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        const errorMessage = data?.error || "Une erreur est survenue lors de l'appel à l'assistant.";
+        renderMessage({
+          role: "error",
+          title: "Erreur",
+          content: errorMessage,
+        });
+        return;
+      }
+
+      if (textarea) {
+        textarea.value = "";
+      }
+
+      renderMessage({
+        role: "question",
+        title: "Vous",
+        content: message,
+      });
+
+      renderMessage({
+        role: "answer",
+        title: data.variant === "admin" ? "Assistant (admin)" : "Assistant",
+        content: data.answer || "Je n'ai pas pu générer de réponse.",
+        sources: Array.isArray(data.sources) ? data.sources : [],
+      });
+    } catch (err) {
+      renderMessage({
+        role: "error",
+        title: "Erreur",
+        content: "Impossible de contacter le serveur. Vérifiez votre connexion et réessayez.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  });
+
+  function setLoading(isLoading) {
+    form.classList.toggle("is-loading", Boolean(isLoading));
+    if (chatbotSection) {
+      chatbotSection.classList.toggle("is-loading", Boolean(isLoading));
+    }
+    if (submitButton) {
+      submitButton.disabled = Boolean(isLoading);
+      submitButton.setAttribute("aria-busy", isLoading ? "true" : "false");
+    }
+  }
+
+  function renderMessage({ role, title, content, sources = [] }) {
+    if (!messagesContainer) {
+      return;
+    }
+
+    if (emptyState) {
+      emptyState.hidden = true;
+    }
+    messagesContainer.hidden = false;
+
+    const wrapper = document.createElement("article");
+    wrapper.className = `chatbot-message chatbot-${role}`;
+
+    const header = document.createElement("header");
+    header.className = "chatbot-message-header";
+    header.textContent = title;
+    wrapper.appendChild(header);
+
+    const body = document.createElement("div");
+    body.className = "chatbot-message-body";
+    body.textContent = content;
+    wrapper.appendChild(body);
+
+    if (sources.length) {
+      const sourcesList = document.createElement("ul");
+      sourcesList.className = "chatbot-sources";
+      sources.forEach((source) => {
+        if (!source) return;
+        const item = document.createElement("li");
+        const strong = document.createElement("strong");
+        strong.textContent = source.source || "Source";
+        item.appendChild(strong);
+        if (source.snippet) {
+          const details = document.createElement("span");
+          details.textContent = ` — ${source.snippet}`;
+          item.appendChild(details);
+        }
+        sourcesList.appendChild(item);
+      });
+      wrapper.appendChild(sourcesList);
+    }
+
+    messagesContainer.appendChild(wrapper);
+    messagesContainer.scrollTo({ top: messagesContainer.scrollHeight, behavior: "smooth" });
+  }
+}
+
+document.addEventListener("DOMContentLoaded", initChatbot);

--- a/public/style.css
+++ b/public/style.css
@@ -652,3 +652,140 @@ textarea {
     right: 1rem;
   }
 }
+
+.chatbot {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.chatbot-header {
+  background: #f5f7fa;
+  border: 1px solid #d9e2ec;
+  border-radius: 8px;
+  padding: 1.25rem;
+}
+
+.chatbot-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chatbot-form textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 120px;
+  padding: 0.75rem;
+  border-radius: 6px;
+  border: 1px solid #cbd2d9;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.chatbot-form textarea:focus {
+  outline: 3px solid #c3ddfd;
+  border-color: #4c63b6;
+}
+
+.chatbot-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.chatbot-controls label {
+  font-weight: 600;
+}
+
+.chatbot-controls select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid #cbd2d9;
+}
+
+.chatbot-form.is-loading,
+.chatbot.is-loading {
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.chatbot-results {
+  border: 1px solid #d9e2ec;
+  border-radius: 8px;
+  padding: 1rem;
+  background: #fbfcff;
+}
+
+.chatbot-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.chatbot-placeholder {
+  text-align: center;
+  color: #52606d;
+}
+
+.chatbot-message {
+  border: 1px solid #d9e2ec;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.chatbot-message.chatbot-answer {
+  border-left: 4px solid #4c63b6;
+}
+
+.chatbot-message.chatbot-question {
+  border-left: 4px solid #0b7285;
+}
+
+.chatbot-message.chatbot-error {
+  border-left: 4px solid #d64545;
+  background: #fff5f5;
+}
+
+.chatbot-message-header {
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.chatbot-message-body {
+  white-space: pre-wrap;
+  margin: 0;
+}
+
+.chatbot-sources {
+  list-style: disc;
+  margin: 0.75rem 0 0 1.5rem;
+  padding: 0;
+  color: #364152;
+}
+
+.chatbot-sources li {
+  margin-bottom: 0.25rem;
+}
+
+.chatbot-sources strong {
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .chatbot-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .chatbot-controls select,
+  .chatbot-controls button {
+    width: 100%;
+  }
+}

--- a/routes/chatbot.js
+++ b/routes/chatbot.js
@@ -1,0 +1,43 @@
+import { Router } from "express";
+import { asyncHandler } from "../utils/asyncHandler.js";
+import { answerQuestion } from "../utils/chatbot.js";
+
+const r = Router();
+
+r.get(
+  "/chatbot",
+  asyncHandler(async (req, res) => {
+    const isAdmin = Boolean(req.session.user?.is_admin);
+    res.render("chatbot", {
+      title: "Assistant IA",
+      chatbot: {
+        isAdmin,
+      },
+    });
+  }),
+);
+
+r.post(
+  "/chatbot/query",
+  asyncHandler(async (req, res) => {
+    const message = typeof req.body?.message === "string" ? req.body.message : "";
+    const variant = req.body?.variant === "admin" ? "admin" : "public";
+
+    if (!message.trim()) {
+      return res.status(400).json({
+        error: "Veuillez poser une question avant d'interroger l'assistant.",
+      });
+    }
+
+    if (variant === "admin" && !req.session.user?.is_admin) {
+      return res.status(403).json({
+        error: "Seul un administrateur peut accéder à cette vue de l'assistant.",
+      });
+    }
+
+    const result = await answerQuestion(message, variant);
+    res.json(result);
+  }),
+);
+
+export default r;

--- a/utils/chatbot.js
+++ b/utils/chatbot.js
@@ -1,0 +1,224 @@
+import { all } from "../db.js";
+
+const CACHE_TTL_MS = 60_000;
+const caches = {
+  public: { entries: null, lastFetchedAt: 0 },
+  admin: { entries: null, lastFetchedAt: 0 },
+};
+
+export async function answerQuestion(question, scope = "public") {
+  const trimmedQuestion = (question || "").trim();
+  if (!trimmedQuestion) {
+    return {
+      answer: "Je n'ai reçu aucune question à analyser.",
+      sources: [],
+      variant: scope,
+    };
+  }
+
+  const searchTerms = extractTerms(trimmedQuestion);
+  if (!searchTerms.length) {
+    return {
+      answer:
+        "Je n'ai pas reconnu de mots-clés exploitables. Reformulez la question avec des termes plus précis.",
+      sources: [],
+      variant: scope,
+    };
+  }
+
+  const entries = await getKnowledgeBase(scope);
+  const ranked = entries
+    .map((entry) => ({
+      ...entry,
+      score: computeScore(entry.searchText, searchTerms),
+    }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3);
+
+  if (!ranked.length) {
+    return {
+      answer:
+        "Je n'ai rien trouvé correspondant à votre question. Essayez avec d'autres mots-clés ou vérifiez l'orthographe.",
+      sources: [],
+      variant: scope,
+    };
+  }
+
+  const lines = ranked.map((entry) => {
+    const snippet = buildSnippet(entry.text, searchTerms);
+    return `• ${entry.source} : ${snippet}`;
+  });
+
+  const header =
+    scope === "admin"
+      ? "Mode administrateur — l'assistant peut consulter l'intégralité de la base de données."
+      : "Mode public — l'assistant utilise uniquement les articles publiés et commentaires approuvés.";
+
+  return {
+    answer: `${header}\n${lines.join("\n")}`,
+    sources: ranked.map((entry) => ({
+      source: entry.source,
+      snippet: buildSnippet(entry.text, searchTerms),
+    })),
+    variant: scope,
+  };
+}
+
+async function getKnowledgeBase(scope) {
+  const now = Date.now();
+  const cache = caches[scope];
+  if (cache?.entries && now - cache.lastFetchedAt < CACHE_TTL_MS) {
+    return cache.entries;
+  }
+
+  const entries =
+    scope === "admin" ? await buildAdminKnowledgeBase() : await buildPublicKnowledgeBase();
+
+  if (cache) {
+    cache.entries = entries;
+    cache.lastFetchedAt = now;
+  }
+
+  return entries;
+}
+
+async function buildPublicKnowledgeBase() {
+  const entries = [];
+
+  const pages = await all(`
+    SELECT p.slug_id, p.title, p.content, p.created_at,
+           COALESCE(GROUP_CONCAT(t.name, ', '), '') AS tags
+    FROM pages p
+    LEFT JOIN page_tags pt ON pt.page_id = p.id
+    LEFT JOIN tags t ON t.id = pt.tag_id
+    GROUP BY p.id
+  `);
+
+  for (const page of pages) {
+    const tagsLine = page.tags ? `\nTags : ${page.tags}` : "";
+    const body = `Titre : ${page.title}\nContenu : ${page.content}${tagsLine}`;
+    entries.push(buildEntry(`Article · ${page.title}`, body));
+  }
+
+  const comments = await all(`
+    SELECT p.title AS pageTitle, c.body, c.author, c.created_at
+    FROM comments c
+    JOIN pages p ON p.id = c.page_id
+    WHERE c.status = 'approved'
+    ORDER BY c.created_at DESC
+  `);
+
+  for (const comment of comments) {
+    const author = comment.author ? comment.author : "Anonyme";
+    const meta = comment.created_at ? ` (${comment.created_at})` : "";
+    const body = `Commentaire sur « ${comment.pageTitle} » par ${author}${meta}\n${comment.body}`;
+    entries.push(buildEntry(`Commentaire · ${comment.pageTitle}`, body));
+  }
+
+  return entries;
+}
+
+async function buildAdminKnowledgeBase() {
+  const baseEntries = await buildPublicKnowledgeBase();
+  const adminEntries = baseEntries.slice();
+
+  const tables = await all(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+  );
+
+  for (const table of tables) {
+    const name = table.name;
+    if (!/^[A-Za-z0-9_]+$/.test(name)) {
+      continue;
+    }
+    const rows = await all(`SELECT * FROM ${name}`);
+    const serialized = rows.length
+      ? JSON.stringify(rows, null, 2)
+      : "Aucune donnée enregistrée pour le moment.";
+    adminEntries.push(
+      buildEntry(`Table ${name}`, `Contenu brut de la table ${name}\n${serialized}`),
+    );
+  }
+
+  return adminEntries;
+}
+
+function buildEntry(source, text) {
+  const safeText = stripHtml(text || "");
+  return {
+    source,
+    text: safeText,
+    searchText: normalizeForSearch(`${source}\n${safeText}`),
+  };
+}
+
+function extractTerms(question) {
+  return normalizeForSearch(question)
+    .split(/\s+/)
+    .map((word) => word.trim())
+    .filter((word) => word.length > 1);
+}
+
+function computeScore(searchText, terms) {
+  let score = 0;
+  for (const term of terms) {
+    const occurrences = countOccurrences(searchText, term);
+    if (occurrences > 0) {
+      score += 1 + Math.log(1 + occurrences);
+    }
+  }
+  return score;
+}
+
+function countOccurrences(haystack, needle) {
+  let count = 0;
+  let position = haystack.indexOf(needle);
+  while (position !== -1) {
+    count += 1;
+    position = haystack.indexOf(needle, position + needle.length);
+  }
+  return count;
+}
+
+function buildSnippet(text, terms) {
+  if (!text) {
+    return "";
+  }
+  const sentences = text.split(/(?<=[.!?\n])\s+/);
+  for (const sentence of sentences) {
+    const normalizedSentence = normalizeForSearch(sentence);
+    if (terms.some((term) => normalizedSentence.includes(term))) {
+      return clampSnippet(sentence.trim());
+    }
+  }
+  return clampSnippet(text.trim());
+}
+
+function clampSnippet(sentence) {
+  if (sentence.length <= 240) {
+    return sentence;
+  }
+  return `${sentence.slice(0, 237)}…`;
+}
+
+function normalizeForSearch(text) {
+  return (text || "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function stripHtml(value) {
+  return value
+    .replace(/<\s*br\s*\/?\s*>/gi, "\n")
+    .replace(/<\/(p|div|section|li|h[1-6])\s*>/gi, "\n")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\r\n|\r/g, "\n")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{2,}/g, "\n\n")
+    .trim();
+}

--- a/views/chatbot.ejs
+++ b/views/chatbot.ejs
@@ -1,0 +1,44 @@
+<% title = 'Assistant IA'; %>
+<% const isAdmin = chatbot && chatbot.isAdmin; %>
+
+<section class="chatbot" aria-labelledby="chatbotHeading">
+  <header class="chatbot-header">
+    <h1 id="chatbotHeading">Assistant IA du wiki</h1>
+    <p>
+      Posez une question sur le contenu du wiki pour obtenir une réponse synthétique. La version publique
+      exploite uniquement les articles publiés et les commentaires approuvés. Les administrateurs peuvent activer
+      un mode avancé couvrant l’intégralité de la base de données.
+    </p>
+  </header>
+
+  <form class="chatbot-form" data-chatbot-form method="post" action="/chatbot/query">
+    <label class="sr-only" for="chatbotQuestion">Question</label>
+    <textarea
+      id="chatbotQuestion"
+      name="message"
+      rows="3"
+      required
+      placeholder="Exemples : Quels sont les derniers articles publiés ? Comment fonctionne la modération ?"
+    ></textarea>
+
+    <div class="chatbot-controls">
+      <label for="chatbotVariant">Source de données</label>
+      <select id="chatbotVariant" name="variant">
+        <option value="public">Articles + commentaires</option>
+        <% if (isAdmin) { %>
+          <option value="admin">Mode administrateur (toutes les tables)</option>
+        <% } %>
+      </select>
+      <button class="btn success" type="submit" data-icon="🤖">Interroger l’assistant</button>
+    </div>
+  </form>
+
+  <section class="chatbot-results" aria-live="polite" aria-label="Réponses de l’assistant">
+    <div class="chatbot-placeholder" data-chatbot-empty>
+      <p>Les réponses apparaîtront ici. Commencez par poser une question à l’assistant.</p>
+    </div>
+    <div class="chatbot-messages" data-chatbot-messages hidden></div>
+  </section>
+</section>
+
+<script defer src="/public/chatbot.js"></script>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -88,6 +88,7 @@
   <ul>
     <li><a href="/">Accueil</a></li>
     <li><a href="/rss.xml" target="_blank" rel="noopener">Flux RSS</a></li>
+    <li><a href="/chatbot">Assistant IA</a></li>
     <% if (typeof canViewIpProfile !== 'undefined' && canViewIpProfile) { %>
       <li><a href="/profiles/ip/me">Mon profil IP</a></li>
     <% } %>


### PR DESCRIPTION
## Summary
- add a chatbot route that exposes public and administrator conversation modes backed by wiki data
- build a knowledge base aggregator that indexes published content and full database exports for admins
- create a dedicated assistant UI with styling, frontend logic, and navigation entry

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68dc4a2104f48321a92d8335a4c488dd