### PR TITLE
Use snowflake IDs in admin IP tooling

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -2608,9 +2608,9 @@ r.get("/events", async (req, res) => {
   if (searchTerm) {
     const like = `%${searchTerm}%`;
     filters.push(
-      "(CAST(id AS TEXT) LIKE ? OR COALESCE(channel,'') LIKE ? OR COALESCE(type,'') LIKE ? OR COALESCE(username,'') LIKE ? OR COALESCE(ip,'') LIKE ? OR COALESCE(payload,'') LIKE ?)",
+      "(COALESCE(snowflake_id,'') LIKE ? OR CAST(id AS TEXT) LIKE ? OR COALESCE(channel,'') LIKE ? OR COALESCE(type,'') LIKE ? OR COALESCE(username,'') LIKE ? OR COALESCE(ip,'') LIKE ? OR COALESCE(payload,'') LIKE ?)",
     );
-    params.push(like, like, like, like, like, like);
+    params.push(like, like, like, like, like, like, like);
   }
   const where = filters.length ? `WHERE ${filters.join(" AND ")}` : "";
 
@@ -2622,7 +2622,7 @@ r.get("/events", async (req, res) => {
   const basePagination = buildPagination(req, totalEvents);
   const offset = (basePagination.page - 1) * basePagination.perPage;
   const events = await all(
-    `SELECT id, channel, type, payload, ip, username, created_at
+    `SELECT snowflake_id, id, channel, type, payload, ip, username, created_at
        FROM event_logs
        ${where}
       ORDER BY created_at DESC

--- a/views/admin/events.ejs
+++ b/views/admin/events.ejs
@@ -42,7 +42,9 @@
         <tbody>
           <% events.forEach(ev => { %>
             <tr>
-              <td><%= ev.id %></td>
+              <td>
+                <code><%= ev.snowflake_id || `legacy-${ev.id}` %></code>
+              </td>
               <td><strong><%= ev.type %></strong></td>
               <td><code><%= ev.channel %></code></td>
               <td><%= ev.username || '-' %></td>

--- a/views/admin/ip_profiles.ejs
+++ b/views/admin/ip_profiles.ejs
@@ -9,7 +9,7 @@
         type="text"
         name="search"
         value="<%= typeof searchTerm === 'string' ? searchTerm : '' %>"
-        placeholder="Hash, IP…"
+        placeholder="ID Snowflake, hash, IP…"
         class="flex-basis-260"
       />
     </label>
@@ -48,12 +48,15 @@
             <td>
               <strong>
                 <a href="/profiles/ip/<%= profile.hash %>" target="_blank" rel="noopener">
-                  Profil #<%= profile.shortHash %>
+                  Profil <code><%= profile.snowflakeId || `#${profile.shortHash}` %></code>
                 </a>
               </strong>
               <br />
               <small class="text-muted">
                 Créé : <%= profile.createdAt ? new Date(profile.createdAt).toLocaleString('fr-FR') : 'Inconnu' %>
+                <% if (!profile.snowflakeId && profile.shortHash) { %>
+                  <br />Identifiant legacy : <code>#<%= profile.shortHash %></code>
+                <% } %>
               </small>
             </td>
             <td><code><%= profile.ip %></code></td>

--- a/views/admin/ip_reputation.ejs
+++ b/views/admin/ip_reputation.ejs
@@ -87,7 +87,9 @@
             <div>
               <code class="admin-risk-ip"><%= profile.ip %></code>
               <span class="status-pill suspicious">Suspecte</span>
-              <span class="text-muted">Profil #<%= profile.shortHash %></span>
+              <span class="text-muted">
+                ID : <code><%= profile.snowflakeId || `#${profile.shortHash}` %></code>
+              </span>
               <% if (profile.bot?.isBot) { %>
                 <span class="status-pill suspicious">Bot suspecté</span>
               <% } %>
@@ -151,7 +153,7 @@
           <div class="admin-cleared-header">
             <code><%= profile.ip %></code>
             <span class="status-pill safe">Sûre</span>
-            <span class="text-muted">Profil #<%= profile.shortHash %></span>
+            <span class="text-muted">ID : <code><%= profile.snowflakeId || `#${profile.shortHash}` %></code></span>
             <% if (profile.bot?.isBot) { %>
               <span class="status-pill suspicious">Bot suspecté</span>
             <% } %>
@@ -210,7 +212,9 @@
               <td>
                 <code><%= entry.ip %></code>
                 <br />
-                <small class="text-muted">Profil #<%= entry.shortHash %></small>
+                <small class="text-muted">
+                  ID : <code><%= entry.snowflakeId || `#${entry.shortHash}` %></code>
+                </small>
               </td>
               <td>
                 <span class="<%= getReputationStatusClass(entry.status) %>">

--- a/views/ip_profile.ejs
+++ b/views/ip_profile.ejs
@@ -1,4 +1,5 @@
-<% const displayTitle = `Profil IP #${profile.shortHash}`; %>
+<% const displayIdentifier = profile.snowflakeId || `#${profile.shortHash}`; %>
+<% const displayTitle = `Profil IP ${displayIdentifier}`; %>
 <% title = displayTitle; %>
 <% const rep = profile.reputation || {}; %>
 <% const repStatus = rep.status || 'unknown'; %>
@@ -69,7 +70,12 @@
         <% } %>
         <div>
           <dt>Identifiant</dt>
-          <dd><code>#<%= profile.shortHash %></code></dd>
+          <dd>
+            <code><%= displayIdentifier %></code>
+            <% if (profile.snowflakeId && profile.shortHash) { %>
+              <br /><small class="text-muted">Legacy : #<%= profile.shortHash %></small>
+            <% } %>
+          </dd>
         </div>
       </dl>
     </div>


### PR DESCRIPTION
## Summary
- include snowflake IDs in admin event log searches and listings
- expose snowflake identifiers in IP profile data loaders used across the admin dashboard
- surface snowflake IDs in IP reputation dashboards and public IP profile pages with legacy fallbacks

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dcf7e811b48321a0a6aa747cc2eaae