### PR TITLE
Use snowflake IDs across admin interfaces

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1738,7 +1738,7 @@ r.get("/stats", async (req, res) => {
         LIMIT 6`,
     ),
     all(
-      `SELECT type, channel, created_at, username
+      `SELECT snowflake_id, type, channel, created_at, username
          FROM event_logs
         ORDER BY created_at DESC
         LIMIT 8`,
@@ -2608,9 +2608,9 @@ r.get("/events", async (req, res) => {
   if (searchTerm) {
     const like = `%${searchTerm}%`;
     filters.push(
-      "(CAST(id AS TEXT) LIKE ? OR COALESCE(channel,'') LIKE ? OR COALESCE(type,'') LIKE ? OR COALESCE(username,'') LIKE ? OR COALESCE(ip,'') LIKE ? OR COALESCE(payload,'') LIKE ?)",
+      "(COALESCE(snowflake_id,'') LIKE ? OR CAST(id AS TEXT) LIKE ? OR COALESCE(channel,'') LIKE ? OR COALESCE(type,'') LIKE ? OR COALESCE(username,'') LIKE ? OR COALESCE(ip,'') LIKE ? OR COALESCE(payload,'') LIKE ?)",
     );
-    params.push(like, like, like, like, like, like);
+    params.push(like, like, like, like, like, like, like);
   }
   const where = filters.length ? `WHERE ${filters.join(" AND ")}` : "";
 
@@ -2622,7 +2622,7 @@ r.get("/events", async (req, res) => {
   const basePagination = buildPagination(req, totalEvents);
   const offset = (basePagination.page - 1) * basePagination.perPage;
   const events = await all(
-    `SELECT id, channel, type, payload, ip, username, created_at
+    `SELECT snowflake_id, id, channel, type, payload, ip, username, created_at
        FROM event_logs
        ${where}
       ORDER BY created_at DESC

--- a/views/admin/events.ejs
+++ b/views/admin/events.ejs
@@ -42,7 +42,7 @@
         <tbody>
           <% events.forEach(ev => { %>
             <tr>
-              <td><%= ev.id %></td>
+              <td><code><%= ev.snowflake_id || ev.id %></code></td>
               <td><strong><%= ev.type %></strong></td>
               <td><code><%= ev.channel %></code></td>
               <td><%= ev.username || '-' %></td>

--- a/views/admin/ip_profiles.ejs
+++ b/views/admin/ip_profiles.ejs
@@ -55,6 +55,10 @@
               <small class="text-muted">
                 Créé : <%= profile.createdAt ? new Date(profile.createdAt).toLocaleString('fr-FR') : 'Inconnu' %>
               </small>
+              <% if (profile.id) { %>
+                <br />
+                <small class="text-muted">ID : <code><%= profile.id %></code></small>
+              <% } %>
             </td>
             <td><code><%= profile.ip %></code></td>
             <td>

--- a/views/admin/ip_reputation.ejs
+++ b/views/admin/ip_reputation.ejs
@@ -87,7 +87,12 @@
             <div>
               <code class="admin-risk-ip"><%= profile.ip %></code>
               <span class="status-pill suspicious">Suspecte</span>
-              <span class="text-muted">Profil #<%= profile.shortHash %></span>
+              <span class="text-muted">
+                Profil #<%= profile.shortHash %>
+                <% if (profile.id) { %>
+                  · ID : <code><%= profile.id %></code>
+                <% } %>
+              </span>
               <% if (profile.bot?.isBot) { %>
                 <span class="status-pill suspicious">Bot suspecté</span>
               <% } %>
@@ -151,7 +156,12 @@
           <div class="admin-cleared-header">
             <code><%= profile.ip %></code>
             <span class="status-pill safe">Sûre</span>
-            <span class="text-muted">Profil #<%= profile.shortHash %></span>
+            <span class="text-muted">
+              Profil #<%= profile.shortHash %>
+              <% if (profile.id) { %>
+                · ID : <code><%= profile.id %></code>
+              <% } %>
+            </span>
             <% if (profile.bot?.isBot) { %>
               <span class="status-pill suspicious">Bot suspecté</span>
             <% } %>
@@ -210,7 +220,12 @@
               <td>
                 <code><%= entry.ip %></code>
                 <br />
-                <small class="text-muted">Profil #<%= entry.shortHash %></small>
+                <small class="text-muted">
+                  Profil #<%= entry.shortHash %>
+                  <% if (entry.id) { %>
+                    <br />ID : <code><%= entry.id %></code>
+                  <% } %>
+                </small>
               </td>
               <td>
                 <span class="<%= getReputationStatusClass(entry.status) %>">

--- a/views/admin/stats.ejs
+++ b/views/admin/stats.ejs
@@ -275,6 +275,9 @@
             <div>
               <span class="highlight-label"><%= event.type %></span>
               <span class="text-muted text-sm">Canal : <%= event.channel %></span>
+              <% if (event.snowflake_id) { %>
+                <br /><small class="text-muted">ID : <code><%= event.snowflake_id %></code></small>
+              <% } %>
             </div>
             <div class="text-muted text-sm">
               <time datetime="<%= event.created_at %>"><%= new Date(event.created_at).toLocaleString('fr-FR') %></time>

--- a/views/ip_profile.ejs
+++ b/views/ip_profile.ejs
@@ -69,7 +69,13 @@
         <% } %>
         <div>
           <dt>Identifiant</dt>
-          <dd><code>#<%= profile.shortHash %></code></dd>
+          <dd>
+            <code>#<%= profile.shortHash %></code>
+            <% if (profile.id) { %>
+              <br />
+              <small>ID : <code><%= profile.id %></code></small>
+            <% } %>
+          </dd>
         </div>
       </dl>
     </div>


### PR DESCRIPTION
## Summary
- expose snowflake identifiers for event logs in admin queries and search filters
- surface snowflake identifiers across IP profile data helpers and related admin/public views
- display the snowflake IDs within the admin dashboard, IP profile listings, and reputation monitoring screens

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dcf7e811b48321a0a6aa747cc2eaae