### PR TITLE
Add admin snowflake decoder

### DIFF
--- a/utils/snowflake.js
+++ b/utils/snowflake.js
@@ -1,7 +1,23 @@
 const CUSTOM_EPOCH = BigInt(1704067200000); // 2024-01-01T00:00:00Z
+const SNOWFLAKE_TIME_SHIFT = BigInt(22);
+const RANDOM_BIT_LENGTH = 10;
+const SEQUENCE_BIT_LENGTH = 12;
+const TIME_BIT_LENGTH = 64 - RANDOM_BIT_LENGTH - SEQUENCE_BIT_LENGTH;
+const RANDOM_SHIFT = BigInt(SEQUENCE_BIT_LENGTH);
+const RANDOM_MASK = (BigInt(1) << BigInt(RANDOM_BIT_LENGTH)) - BigInt(1);
+const SEQUENCE_MASK = (BigInt(1) << BigInt(SEQUENCE_BIT_LENGTH)) - BigInt(1);
+
 let lastTimestamp = BigInt(0);
 let sequence = BigInt(0);
-const MAX_SEQUENCE = BigInt(4095); // 12 bits
+const MAX_SEQUENCE = SEQUENCE_MASK;
+
+export const SNOWFLAKE_EPOCH_MS = Number(CUSTOM_EPOCH);
+export const SNOWFLAKE_STRUCTURE = Object.freeze({
+  totalBits: 64,
+  timeBits: TIME_BIT_LENGTH,
+  randomBits: RANDOM_BIT_LENGTH,
+  sequenceBits: SEQUENCE_BIT_LENGTH,
+});
 
 export function generateSnowflake() {
   let timestamp = BigInt(Date.now());
@@ -17,18 +33,60 @@ export function generateSnowflake() {
     sequence = BigInt(0);
   }
   lastTimestamp = timestamp;
-  const timeComponent = (timestamp - CUSTOM_EPOCH) << BigInt(22);
+  const timeComponent = (timestamp - CUSTOM_EPOCH) << SNOWFLAKE_TIME_SHIFT;
   const randomBits = BigInt(Math.floor(Math.random() * 1024)); // 10 bits of randomness
-  const snowflake = timeComponent | (randomBits << BigInt(12)) | sequence;
+  const snowflake = timeComponent | (randomBits << RANDOM_SHIFT) | sequence;
   return snowflake.toString();
 }
 
-export function parseSnowflake(value) {
+function toPaddedBinary(value, bitLength) {
+  const binary = BigInt(value).toString(2);
+  return binary.padStart(bitLength, "0");
+}
+
+export function decomposeSnowflake(value, { now = Date.now() } = {}) {
   try {
     const snowflake = BigInt(value);
-    const timestamp = Number((snowflake >> BigInt(22)) + CUSTOM_EPOCH);
-    return new Date(timestamp);
+    const timeComponent = snowflake >> SNOWFLAKE_TIME_SHIFT;
+    const timestampMs = Number(timeComponent + CUSTOM_EPOCH);
+    const createdAt = new Date(timestampMs);
+    if (Number.isNaN(createdAt.getTime())) {
+      return null;
+    }
+    const randomComponent = Number((snowflake >> RANDOM_SHIFT) & RANDOM_MASK);
+    const sequenceComponent = Number(snowflake & SEQUENCE_MASK);
+    return {
+      value: snowflake.toString(),
+      hex: snowflake.toString(16),
+      binary: snowflake.toString(2).padStart(SNOWFLAKE_STRUCTURE.totalBits, "0"),
+      epochMs: SNOWFLAKE_EPOCH_MS,
+      timestamp: {
+        milliseconds: timestampMs,
+        iso: createdAt.toISOString(),
+        sinceEpochMs: Number(timeComponent),
+        binary: toPaddedBinary(timeComponent, TIME_BIT_LENGTH),
+      },
+      random: {
+        value: randomComponent,
+        bits: RANDOM_BIT_LENGTH,
+        binary: toPaddedBinary(randomComponent, RANDOM_BIT_LENGTH),
+      },
+      sequence: {
+        value: sequenceComponent,
+        bits: SEQUENCE_BIT_LENGTH,
+        binary: toPaddedBinary(sequenceComponent, SEQUENCE_BIT_LENGTH),
+      },
+      ageMs: now - timestampMs,
+    };
   } catch (_err) {
     return null;
   }
+}
+
+export function parseSnowflake(value) {
+  const parts = decomposeSnowflake(value);
+  if (!parts) {
+    return null;
+  }
+  return new Date(parts.timestamp.milliseconds);
 }

--- a/views/admin/snowflakes.ejs
+++ b/views/admin/snowflakes.ejs
@@ -1,0 +1,149 @@
+<% title = 'Snowflakes'; %>
+<h1>Décodeur de snowflakes</h1>
+
+<form method="get" class="card mb-md">
+  <div class="flex flex-wrap gap-sm items-end">
+    <label class="stack-form">
+      <span class="text-sm text-muted">Identifiant snowflake</span>
+      <input
+        type="text"
+        name="id"
+        value="<%= typeof queryId === 'string' ? queryId : '' %>"
+        placeholder="Ex : 1952213762766886912"
+        class="flex-basis-320"
+        required
+      />
+    </label>
+    <button class="btn" data-icon="🔍" type="submit">Analyser</button>
+    <% if (queryId) { %>
+      <a class="btn secondary" href="/admin/snowflakes">Réinitialiser</a>
+    <% } %>
+  </div>
+  <p class="text-sm text-muted mt-sm">
+    Structure : <strong><%= structure.timeBits %>b</strong> temps ·
+    <strong><%= structure.randomBits %>b</strong> aléatoire ·
+    <strong><%= structure.sequenceBits %>b</strong> séquence.<br />
+    Epoch : <code><%= epoch.iso %></code> (<%= epoch.localized %>).
+  </p>
+</form>
+
+<% if (error) { %>
+  <div class="alert alert-error mb-md"><%= error %></div>
+<% } %>
+
+<% if (decoded && decoded.value) { %>
+  <% const binarySegments = [decoded.timestamp.binary, decoded.random.binary, decoded.sequence.binary]; %>
+  <section class="card mb-md">
+    <h2>Informations générales</h2>
+    <p class="text-sm text-muted">
+      Analyse effectuée le <strong><%= now.localized %></strong>
+      (<code><%= now.iso %></code>).
+    </p>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Champ</th>
+            <th>Valeur</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Identifiant</th>
+            <td><code><%= decoded.value %></code></td>
+          </tr>
+          <tr>
+            <th scope="row">Hexadécimal</th>
+            <td><code>0x<%= decoded.hex %></code></td>
+          </tr>
+          <tr>
+            <th scope="row">Binaire (segmenté)</th>
+            <td>
+              <code>
+                <%= binarySegments[0] %>
+              </code>
+              <span aria-hidden="true"> | </span>
+              <code>
+                <%= binarySegments[1] %>
+              </code>
+              <span aria-hidden="true"> | </span>
+              <code>
+                <%= binarySegments[2] %>
+              </code>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Créé le</th>
+            <td>
+              <strong><%= decoded.createdAtLocalized %></strong><br />
+              <code><%= decoded.timestamp.iso %></code>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Horodatage UNIX</th>
+            <td><code><%= decoded.createdAtUnixSeconds %></code> secondes</td>
+          </tr>
+          <tr>
+            <th scope="row">Depuis l’epoch personnalisée</th>
+            <td><code><%= decoded.timestamp.sinceEpochMs %></code> ms</td>
+          </tr>
+          <tr>
+            <th scope="row">Âge</th>
+            <td>
+              <%= decoded.relativeAge %>
+              (<%= decoded.absoluteAgeSeconds %> s)
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2>Composition du snowflake</h2>
+    <div class="table-wrap">
+      <table class="data-table compact">
+        <thead>
+          <tr>
+            <th>Segment</th>
+            <th>Bits</th>
+            <th>Binaire</th>
+            <th>Décimal</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Temps</th>
+            <td><%= structure.timeBits %></td>
+            <td><code><%= decoded.timestamp.binary %></code></td>
+            <td><code><%= decoded.timestamp.sinceEpochMs %></code></td>
+          </tr>
+          <tr>
+            <th scope="row">Aléatoire</th>
+            <td><%= structure.randomBits %></td>
+            <td><code><%= decoded.random.binary %></code></td>
+            <td><code><%= decoded.random.value %></code></td>
+          </tr>
+          <tr>
+            <th scope="row">Séquence</th>
+            <td><%= structure.sequenceBits %></td>
+            <td><code><%= decoded.sequence.binary %></code></td>
+            <td><code><%= decoded.sequence.value %></code></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="text-sm text-muted mt-sm">
+      Les bits aléatoires permettent de réduire les collisions lors de la génération
+      simultanée, tandis que la séquence assure l’unicité au sein de la même milliseconde.
+    </p>
+  </section>
+<% } else if (!queryId) { %>
+  <div class="card">
+    <p class="text-muted">
+      Entrez un identifiant snowflake pour afficher sa date de création, ses segments binaires
+      et les métadonnées associées. Vous pouvez par exemple copier l’ID d’un commentaire,
+      d’un like ou d’une page depuis l’administration.
+    </p>
+  </div>
+<% } %>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -126,6 +126,7 @@
           Demandes de déban<% if (adminCounts.pendingBanAppeals) { %> (<%= adminCounts.pendingBanAppeals %>)<% } %>
         </a>
       </li>
+      <li><a href="/admin/snowflakes">Snowflakes</a></li>
       <li><a href="/admin/events">Événements</a></li>
       <li><a href="/admin/uploads">Images</a></li>
       <li><a href="/admin/settings">Paramètres</a></li>


### PR DESCRIPTION
## Summary
- expose snowflake structure metadata and decomposition helper in the snowflake utility
- add an admin-only snowflake decoder page with detailed breakdown of identifiers
- surface the decoder through the admin navigation alongside formatting helpers

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68dcfd0c50448321af6b9c13e802165e