### PR TITLE
Replace UUID usage with snowflakes

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -2,7 +2,6 @@ import fs from "fs/promises";
 import { Router } from "express";
 import multer from "multer";
 import path from "path";
-import { randomUUID } from "crypto";
 import { requireAdmin } from "../middleware/auth.js";
 import { all, get, run, randId, savePageFts } from "../db.js";
 import {
@@ -84,7 +83,7 @@ const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, uploadDir),
   filename: (_req, file, cb) => {
     const ext = path.extname(file.originalname).toLowerCase();
-    const id = randomUUID();
+    const id = generateSnowflake();
     cb(null, `${id}${ext}`);
   },
 });

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { randomUUID } from "crypto";
 import {
   get,
   run,
@@ -452,7 +451,7 @@ r.post(
       return res.redirect(`/wiki/${page.slug_id}#comments`);
     }
 
-    const token = randomUUID();
+    const token = generateSnowflake();
     const commentSnowflake = generateSnowflake();
     const insertResult = await run(
       `INSERT INTO comments(
@@ -554,7 +553,7 @@ r.post(
     const bodyValidation = validateCommentBody(req.body.body);
     if (bodyValidation.errors.length) {
       const inlineNotifications = bodyValidation.errors.map((message) => ({
-        id: randomUUID(),
+        id: generateSnowflake(),
         type: "error",
         message,
         timeout: 6000,

--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { generateSnowflake } from "./snowflake.js";
 
 const DEFAULT_TIMEOUT = 5000;
 
@@ -28,7 +28,7 @@ export function pushNotification(
     req.session.notifications = [];
   }
   req.session.notifications.push({
-    id: randomUUID(),
+    id: generateSnowflake(),
     type,
     message,
     timeout: Number.isFinite(timeout) ? timeout : DEFAULT_TIMEOUT,

--- a/views/admin/uploads.ejs
+++ b/views/admin/uploads.ejs
@@ -3,8 +3,8 @@
 <div class="card mb-md">
   <h2>Ajouter une image</h2>
   <p class="mt-xs">
-    Chaque image reçoit un identifiant unique (UUID). Les fichiers volumineux sont automatiquement redimensionnés et optimisés.
-    Vous pouvez définir un nom personnalisé sans changer l’UUID. Laissez le champ vide pour effacer le nom personnalisé.
+    Chaque image reçoit un identifiant unique (snowflake). Les fichiers volumineux sont automatiquement redimensionnés et optimisés.
+    Vous pouvez définir un nom personnalisé sans changer le snowflake. Laissez le champ vide pour effacer le nom personnalisé.
   </p>
   <form id="uploadForm" action="/admin/uploads" method="post" enctype="multipart/form-data" class="flex flex-wrap gap-sm mt-sm">
     <div class="flex-basis-220">
@@ -28,7 +28,7 @@
         type="text"
         name="search"
         value="<%= typeof searchTerm === 'string' ? searchTerm : '' %>"
-        placeholder="UUID, nom de fichier…"
+        placeholder="Snowflake, nom de fichier…"
         class="flex-basis-260"
       />
     </label>
@@ -62,7 +62,7 @@
               <img src="<%= upload.url %>" alt="" class="upload-thumb" />
             </td>
           <td class="leading-snug">
-            <div><strong>UUID :</strong> <code><%= upload.id %></code></div>
+            <div><strong>Snowflake :</strong> <code><%= upload.id %></code></div>
             <div><strong>Nom original :</strong> <%= upload.originalName %></div>
             <div><strong>Nom affiché :</strong> <%= displayName || '—' %></div>
             <div><strong>Taille :</strong> <%= sizeLabel %></div>
@@ -167,7 +167,7 @@
         <img src="${safeUrl}" alt="" class="upload-thumb" />
       </td>
       <td class="leading-snug">
-        <div><strong>UUID :</strong> <code>${safeId}</code></div>
+        <div><strong>Snowflake :</strong> <code>${safeId}</code></div>
         <div><strong>Nom original :</strong> ${escapeHtml(originalName)}</div>
         <div><strong>Nom affiché :</strong> ${displayName ? escapeHtml(displayName) : '—'}</div>
         <div><strong>Taille :</strong> ${Math.max(1, Math.round((data.size || 0) / 1024))} Ko</div>


### PR DESCRIPTION
## Summary
- switch upload filenames and admin messaging from UUIDs to snowflake identifiers
- replace random UUID generation in notifications and comment flows with snowflakes for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd00839a488321a07bc469e9204368