### PR TITLE
refactor: extract shared role helpers

### DIFF
--- a/utils/roleFlags.js
+++ b/utils/roleFlags.js
@@ -1,0 +1,99 @@
+export const ROLE_FLAG_FIELDS = [
+  "is_admin",
+  "is_moderator",
+  "is_helper",
+  "is_contributor",
+];
+
+export function deriveRoleFlags(rawUser = {}) {
+  const flags = {
+    is_admin: Boolean(rawUser.is_admin),
+    is_moderator: Boolean(rawUser.is_moderator),
+    is_helper: Boolean(rawUser.is_helper),
+    is_contributor: Boolean(rawUser.is_contributor),
+  };
+
+  const roleOverrides = ROLE_FLAG_FIELDS.reduce((acc, key) => {
+    const roleKey = `role_${key}`;
+    if (rawUser[roleKey] !== undefined && rawUser[roleKey] !== null) {
+      acc[key] = Boolean(rawUser[roleKey]);
+    }
+    return acc;
+  }, {});
+
+  const merged = { ...flags, ...roleOverrides };
+  if (merged.is_admin) {
+    return {
+      is_admin: true,
+      is_moderator: true,
+      is_helper: true,
+      is_contributor: true,
+    };
+  }
+  if (merged.is_moderator) {
+    return {
+      is_admin: false,
+      is_moderator: true,
+      is_helper: true,
+      is_contributor: true,
+    };
+  }
+  if (merged.is_contributor) {
+    return {
+      is_admin: false,
+      is_moderator: false,
+      is_helper: true,
+      is_contributor: true,
+    };
+  }
+  if (merged.is_helper) {
+    return {
+      is_admin: false,
+      is_moderator: false,
+      is_helper: true,
+      is_contributor: false,
+    };
+  }
+  return {
+    is_admin: false,
+    is_moderator: false,
+    is_helper: false,
+    is_contributor: false,
+  };
+}
+
+export function buildSessionUser(rawUser, overrides = null) {
+  const flags = deriveRoleFlags(rawUser);
+  if (overrides) {
+    for (const field of ROLE_FLAG_FIELDS) {
+      if (overrides[field] !== undefined) {
+        flags[field] = Boolean(overrides[field]);
+      }
+    }
+  }
+  return {
+    id: rawUser.id,
+    username: rawUser.username,
+    display_name: rawUser.display_name || null,
+    role_id: rawUser.role_id || null,
+    role_name: rawUser.role_name || null,
+    ...flags,
+  };
+}
+
+export function needsRoleFlagSync(rawUser) {
+  if (!rawUser) return false;
+  const flags = deriveRoleFlags(rawUser);
+  return ROLE_FLAG_FIELDS.some((field) => {
+    const currentValue = Boolean(rawUser[field]);
+    return currentValue !== flags[field];
+  });
+}
+
+export function getRoleFlagValues(flags) {
+  return ROLE_FLAG_FIELDS.map((field) => (flags[field] ? 1 : 0));
+}
+
+export function getRoleFlagPairs(flags) {
+  return ROLE_FLAG_FIELDS.map((field) => [field, flags[field] ? 1 : 0]);
+}

--- a/utils/roleService.js
+++ b/utils/roleService.js
@@ -1,0 +1,141 @@
+import { all, get, run } from "../db.js";
+import { generateSnowflake } from "./snowflake.js";
+import { ROLE_FLAG_FIELDS, getRoleFlagValues } from "./roleFlags.js";
+
+function normalizeBoolean(value) {
+  if (typeof value === "string") {
+    const lower = value.trim().toLowerCase();
+    return lower === "1" || lower === "true" || lower === "on";
+  }
+  return Boolean(value);
+}
+
+function normalizePermissions(raw = {}) {
+  const normalized = {};
+  for (const field of ROLE_FLAG_FIELDS) {
+    normalized[field] = normalizeBoolean(raw[field]);
+  }
+  return normalized;
+}
+
+function mapRoleRow(row) {
+  if (!row) {
+    return null;
+  }
+  const normalizedFlags = {};
+  for (const field of ROLE_FLAG_FIELDS) {
+    normalizedFlags[field] = Boolean(row[field]);
+  }
+  return {
+    ...row,
+    ...normalizedFlags,
+  };
+}
+
+export async function listRoles() {
+  const rows = await all(
+    `SELECT id, snowflake_id, name, description, is_admin, is_moderator, is_helper, is_contributor, created_at, updated_at
+     FROM roles
+     ORDER BY name COLLATE NOCASE`,
+  );
+  return rows.map(mapRoleRow);
+}
+
+export async function listRolesWithUsage() {
+  const roles = await listRoles();
+  const usage = await all(
+    "SELECT role_id, COUNT(*) AS total FROM users WHERE role_id IS NOT NULL GROUP BY role_id",
+  );
+  const usageMap = new Map(usage.map((row) => [row.role_id, Number(row.total) || 0]));
+  return roles.map((role) => ({
+    ...role,
+    userCount: usageMap.get(role.id) || 0,
+  }));
+}
+
+export async function getRoleById(roleId) {
+  if (!roleId) return null;
+  const row = await get(
+    `SELECT id, snowflake_id, name, description, is_admin, is_moderator, is_helper, is_contributor, created_at, updated_at
+     FROM roles
+     WHERE id=?`,
+    [roleId],
+  );
+  return mapRoleRow(row);
+}
+
+export async function getRoleByName(name) {
+  if (!name) return null;
+  const row = await get(
+    `SELECT id, snowflake_id, name, description, is_admin, is_moderator, is_helper, is_contributor, created_at, updated_at
+     FROM roles
+     WHERE name=? COLLATE NOCASE`,
+    [name],
+  );
+  return mapRoleRow(row);
+}
+
+export async function createRole({ name, description = "", permissions = {} }) {
+  const trimmedName = (name || "").trim();
+  if (!trimmedName) {
+    throw new Error("Nom de rôle requis");
+  }
+  const trimmedDescription = description ? description.trim() : null;
+  const perms = normalizePermissions(permissions);
+  const result = await run(
+    "INSERT INTO roles(snowflake_id, name, description, is_admin, is_moderator, is_helper, is_contributor) VALUES(?,?,?,?,?,?,?)",
+    [
+      generateSnowflake(),
+      trimmedName,
+      trimmedDescription,
+      ...getRoleFlagValues(perms),
+    ],
+  );
+  return getRoleById(result.lastID);
+}
+
+export async function updateRolePermissions(roleId, { permissions = {} }) {
+  const role = await getRoleById(roleId);
+  if (!role) {
+    return null;
+  }
+  const perms = normalizePermissions(permissions);
+  const flagValues = getRoleFlagValues(perms);
+  await run(
+    "UPDATE roles SET is_admin=?, is_moderator=?, is_helper=?, is_contributor=?, updated_at=CURRENT_TIMESTAMP WHERE id=?",
+    [...flagValues, roleId],
+  );
+  await run(
+    "UPDATE users SET is_admin=?, is_moderator=?, is_helper=?, is_contributor=? WHERE role_id=?",
+    [...flagValues, roleId],
+  );
+  return getRoleById(roleId);
+}
+
+export async function assignRoleToUser(userId, role) {
+  if (!userId) return null;
+  const targetRole =
+    typeof role === "object" && role !== null ? role : await getRoleById(role);
+  if (!targetRole) {
+    return null;
+  }
+  const flagValues = getRoleFlagValues(targetRole);
+  await run(
+    "UPDATE users SET role_id=?, is_admin=?, is_moderator=?, is_helper=?, is_contributor=? WHERE id=?",
+    [targetRole.id, ...flagValues, userId],
+  );
+  return targetRole;
+}
+
+export async function deleteRole(roleId) {
+  if (!roleId) return false;
+  const usage = await get(
+    "SELECT COUNT(*) AS total FROM users WHERE role_id=?",
+    [roleId],
+  );
+  if (usage?.total) {
+    throw new Error("Impossible de supprimer un rôle attribué à des utilisateurs.");
+  }
+  await run("DELETE FROM roles WHERE id=?", [roleId]);
+  return true;
+}

--- a/utils/time.js
+++ b/utils/time.js
@@ -1,0 +1,57 @@
+export function formatSecondsAgo(seconds) {
+  const safeSeconds = Number.isFinite(seconds) ? Math.max(0, Math.floor(seconds)) : 0;
+  if (safeSeconds < 60) {
+    return `${safeSeconds}s`;
+  }
+  const minutes = Math.floor(safeSeconds / 60);
+  if (minutes < 60) {
+    return minutes === 1 ? "1 min" : `${minutes} min`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return hours === 1 ? "1 h" : `${hours} h`;
+  }
+  const days = Math.floor(hours / 24);
+  return days === 1 ? "1 j" : `${days} j`;
+}
+
+export function formatRelativeDurationMs(milliseconds) {
+  const safeMs = Number.isFinite(milliseconds) ? milliseconds : 0;
+  const isFuture = safeMs < 0;
+  const absSeconds = Math.floor(Math.abs(safeMs) / 1000);
+  const prefix = isFuture ? "dans" : "il y a";
+  if (absSeconds <= 0) {
+    return isFuture ? "dans moins d’une seconde" : "il y a moins d’une seconde";
+  }
+  if (absSeconds < 60) {
+    const unit = absSeconds === 1 ? "seconde" : "secondes";
+    return `${prefix} ${absSeconds} ${unit}`;
+  }
+  if (absSeconds < 3600) {
+    const minutes = Math.round(absSeconds / 60);
+    const unit = minutes === 1 ? "minute" : "minutes";
+    return `${prefix} ${minutes} ${unit}`;
+  }
+  if (absSeconds < 86400) {
+    const hours = Math.round(absSeconds / 3600);
+    const unit = hours === 1 ? "heure" : "heures";
+    return `${prefix} ${hours} ${unit}`;
+  }
+  const days = Math.round(absSeconds / 86400);
+  const unit = days === 1 ? "jour" : "jours";
+  return `${prefix} ${days} ${unit}`;
+}
+
+export function formatDateTimeLocalized(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return "";
+  }
+  try {
+    return new Intl.DateTimeFormat("fr-FR", {
+      dateStyle: "full",
+      timeStyle: "long",
+    }).format(date);
+  } catch (error) {
+    return date.toISOString();
+  }
+}

--- a/views/admin/roles.ejs
+++ b/views/admin/roles.ejs
@@ -1,0 +1,85 @@
+<% title='Rôles'; %>
+<h1>Gestion des rôles</h1>
+<p class="text-muted">Créez de nouveaux rôles et ajustez leurs permissions. Les utilisateurs associés héritent automatiquement des permissions de leur rôle.</p>
+
+<section class="card mb-lg">
+  <h2 class="h3">Nouveau rôle</h2>
+  <form method="post" class="grid gap-md" aria-label="Créer un nouveau rôle">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-md">
+      <label class="stack-form">
+        <span class="text-sm text-muted">Nom du rôle <span aria-hidden="true">*</span></span>
+        <input type="text" name="name" placeholder="Nom" required maxlength="80" />
+      </label>
+      <label class="stack-form">
+        <span class="text-sm text-muted">Description</span>
+        <input type="text" name="description" placeholder="Description courte" maxlength="160" />
+      </label>
+    </div>
+    <fieldset class="stack-form">
+      <legend class="text-sm text-muted">Permissions</legend>
+      <div class="flex flex-wrap gap-md">
+        <label class="checkbox">
+          <input type="checkbox" name="is_admin" value="1" />
+          <span>Administrateur (accès complet)</span>
+        </label>
+        <label class="checkbox">
+          <input type="checkbox" name="is_moderator" value="1" />
+          <span>Modérateur (modération des contenus)</span>
+        </label>
+        <label class="checkbox">
+          <input type="checkbox" name="is_contributor" value="1" />
+          <span>Contributeur (création de contenu)</span>
+        </label>
+        <label class="checkbox">
+          <input type="checkbox" name="is_helper" value="1" />
+          <span>Helper (assistance aux contributeurs)</span>
+        </label>
+      </div>
+    </fieldset>
+    <button class="btn success" type="submit" data-icon="➕">Créer le rôle</button>
+  </form>
+</section>
+
+<section class="grid gap-md">
+  <% if (!roles || !roles.length) { %>
+    <p class="card">Aucun rôle défini pour le moment.</p>
+  <% } else { %>
+    <% roles.forEach(role => { %>
+      <article class="card">
+        <div class="flex flex-wrap items-center justify-between gap-sm">
+          <div>
+            <h2 class="h3"><%= role.name %></h2>
+            <% if (role.description) { %>
+              <p class="text-muted"><%= role.description %></p>
+            <% } %>
+          </div>
+          <span class="badge"><%= role.userCount || 0 %> utilisateur<%= (role.userCount || 0) > 1 ? 's' : '' %></span>
+        </div>
+        <form method="post" action="/admin/roles/<%= role.id %>" class="mt-md" aria-label="Mettre à jour les permissions pour <%= role.name %>">
+          <fieldset class="stack-form">
+            <legend class="text-sm text-muted">Permissions</legend>
+            <div class="flex flex-wrap gap-md">
+              <label class="checkbox">
+                <input type="checkbox" name="is_admin" value="1" <%= role.is_admin ? 'checked' : '' %> />
+                <span>Administrateur</span>
+              </label>
+              <label class="checkbox">
+                <input type="checkbox" name="is_moderator" value="1" <%= role.is_moderator ? 'checked' : '' %> />
+                <span>Modérateur</span>
+              </label>
+              <label class="checkbox">
+                <input type="checkbox" name="is_contributor" value="1" <%= role.is_contributor ? 'checked' : '' %> />
+                <span>Contributeur</span>
+              </label>
+              <label class="checkbox">
+                <input type="checkbox" name="is_helper" value="1" <%= role.is_helper ? 'checked' : '' %> />
+                <span>Helper</span>
+              </label>
+            </div>
+          </fieldset>
+          <button class="btn secondary" type="submit" data-icon="💾">Enregistrer</button>
+        </form>
+      </article>
+    <% }) %>
+  <% } %>
+</section>

--- a/views/admin/users.ejs
+++ b/views/admin/users.ejs
@@ -32,13 +32,15 @@
     </label>
     <label class="stack-form">
       <span class="text-sm text-muted">Rôle</span>
-      <select name="role">
-        <option value="user" selected>Utilisateur</option>
-        <option value="admin">Administrateur</option>
-        <option value="moderator">Modérateur</option>
-        <option value="contributor">Contributeur</option>
-        <option value="helper">Helper</option>
-      </select>
+      <% if (Array.isArray(roles) && roles.length) { %>
+        <select name="roleId">
+          <% roles.forEach(role => { %>
+            <option value="<%= role.id %>" <%= defaultRoleId && role.id === defaultRoleId ? 'selected' : '' %>><%= role.name %></option>
+          <% }) %>
+        </select>
+      <% } else { %>
+        <span class="text-danger">Aucun rôle disponible</span>
+      <% } %>
     </label>
     <button class="btn success" data-icon="➕" type="submit">Ajouter</button>
   </div>
@@ -70,27 +72,20 @@
               <button class="btn secondary" data-icon="💾" type="submit">Enregistrer</button>
             </form>
           </td>
-          <td>
-            <%= u.is_admin
-              ? 'Admin'
-              : (u.is_moderator
-                ? 'Modérateur'
-                : (u.is_contributor
-                  ? 'Contributeur'
-                  : (u.is_helper ? 'Helper' : 'Utilisateur')))
-            %>
-          </td>
+          <td><%= u.role_label %></td>
           <td>
             <div class="flex flex-wrap gap-sm items-center">
               <form method="post" action="/admin/users/<%= u.id %>/role" class="flex gap-sm items-center">
                 <label class="sr-only" for="role-<%= u.id %>">Rôle</label>
-                <select id="role-<%= u.id %>" name="role">
-                  <option value="user" <%= !u.is_admin && !u.is_moderator && !u.is_contributor && !u.is_helper ? 'selected' : '' %>>Utilisateur</option>
-                  <option value="admin" <%= u.is_admin ? 'selected' : '' %>>Administrateur</option>
-                  <option value="moderator" <%= u.is_moderator && !u.is_admin ? 'selected' : '' %>>Modérateur</option>
-                  <option value="contributor" <%= u.is_contributor && !u.is_admin && !u.is_moderator ? 'selected' : '' %>>Contributeur</option>
-                  <option value="helper" <%= u.is_helper && !u.is_admin && !u.is_moderator && !u.is_contributor ? 'selected' : '' %>>Helper</option>
-                </select>
+                <% if (Array.isArray(roles) && roles.length) { %>
+                  <select id="role-<%= u.id %>" name="roleId">
+                    <% roles.forEach(role => { %>
+                      <option value="<%= role.id %>" <%= u.role_id === role.id ? 'selected' : '' %>><%= role.name %></option>
+                    <% }) %>
+                  </select>
+                <% } else { %>
+                  <span class="text-danger">Aucun rôle</span>
+                <% } %>
                 <button class="btn secondary" data-icon="⭐" type="submit">Choisir le rôle</button>
               </form>
               <form method="post" action="/admin/users/<%= u.id %>/delete" onsubmit="return confirm('Supprimer cet utilisateur ?')">

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -111,6 +111,7 @@
       <li><a href="/admin/trash">Corbeille</a></li>
       <li><a href="/admin/stats">Statistiques</a></li>
       <li><a href="/admin/users">Utilisateurs</a></li>
+      <li><a href="/admin/roles">Rôles</a></li>
       <li>
         <a href="/admin/comments">
           Commentaires<% if (adminCounts.pendingComments) { %> (<%= adminCounts.pendingComments %>)<% } %>


### PR DESCRIPTION
## Summary
- factorize role flag normalization into reusable utilities and use them across authentication and admin role updates
- centralize time formatting helpers for admin dashboards to keep formatting logic consistent
- update role service operations and session refresh logic to rely on the new helpers for coherent flag management

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68dd3a0ac19c8321b532616e61239fcd