### PR TITLE
Refactor admin permission category layout

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -959,6 +959,85 @@ textarea {
   margin-bottom: 0.75rem;
 }
 
+.permission-manager {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) 1fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.permission-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.permission-sidebar-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.permission-selector {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.permission-selector-item {
+  margin: 0;
+}
+
+.permission-choice {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: #f5f7fa;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.permission-choice:hover,
+.permission-choice:focus {
+  background: #edf2f7;
+  outline: none;
+}
+
+.permission-choice.is-active {
+  border-color: #4c6ef5;
+  background: #eef2ff;
+  box-shadow: 0 0 0 2px rgba(76, 110, 245, 0.15);
+}
+
+.permission-choice .badge {
+  margin-left: auto;
+}
+
+.permission-choice-name {
+  font-weight: 600;
+  color: #0b1f33;
+}
+
+.permission-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.permission-category-panel[hidden] {
+  display: none;
+}
+
 .permission-category {
   margin-bottom: 1.75rem;
 }
@@ -1046,6 +1125,12 @@ textarea {
   justify-content: flex-end;
   gap: 0.5rem;
   margin-top: auto;
+}
+
+@media (max-width: 900px) {
+  .permission-manager {
+    grid-template-columns: 1fr;
+  }
 }
 
 .role-summary-header {

--- a/views/admin/roles.ejs
+++ b/views/admin/roles.ejs
@@ -227,52 +227,88 @@
                 <% if (!permissionGroups.length) { %>
                   <p class="text-sm text-muted">Aucune permission disponible pour le moment.</p>
                 <% } else { %>
-                  <% permissionGroups.forEach((category) => { %>
-                    <% const groups = Array.isArray(category.groups) ? category.groups : []; %>
-                    <section class="permission-category">
-                      <div class="permission-category-header">
-                        <h3 class="permission-category-title"><%= category.label %></h3>
-                        <% if (category.description) { %>
-                          <p class="text-sm text-muted"><%= category.description %></p>
-                        <% } %>
+                  <div class="permission-manager">
+                    <aside class="permission-sidebar card" aria-label="Catégories de permissions">
+                      <div class="permission-sidebar-header">
+                        <h3 class="h4">Catégories</h3>
+                        <p class="text-sm text-muted">Sélectionnez une catégorie pour afficher ses permissions.</p>
                       </div>
-                      <% groups.forEach((group) => { %>
-                        <% const options = Array.isArray(group.permissions) ? group.permissions : []; %>
-                        <div class="permission-group">
-                          <% if (group.label) { %>
-                            <h4 class="permission-group-title"><%= group.label %></h4>
-                          <% } %>
-                          <div class="role-permissions-grid">
-                            <% options.forEach((option) => { %>
-                              <% if (!option || typeof option.field !== 'string') { return; } %>
-                              <% const isLockedAdminPermission = isAdministratorRole && option.field === 'is_admin'; %>
-                              <label class="checkbox role-permission <%= option.isAggregate ? 'is-aggregate' : '' %>">
-                                <input
-                                  type="checkbox"
-                                  name="<%= option.field %>"
-                                  value="1"
-                                  <%= role[option.field] ? 'checked' : '' %>
-                                  <%= isLockedAdminPermission ? 'disabled' : '' %>
-                                />
-                                <% if (isLockedAdminPermission) { %>
-                                  <input type="hidden" name="<%= option.field %>" value="1" />
-                                <% } %>
-                                <span class="permission-title">
-                                  <%= option.label %>
-                                  <% if (option.isAggregate) { %>
-                                    <span class="badge badge-aggregate" aria-label="Permission globale">Macro</span>
-                                  <% } %>
-                                </span>
-                                <% if (option.description) { %>
-                                  <span class="permission-description"><%= option.description %></span>
-                                <% } %>
-                              </label>
-                            <% }) %>
+                      <ul class="permission-selector" data-permission-selector role="list">
+                        <% permissionGroups.forEach((category, categoryIndex) => { %>
+                          <% const groups = Array.isArray(category.groups) ? category.groups : []; %>
+                          <% const permissionCount = groups.reduce((total, group) => {
+                            const options = Array.isArray(group.permissions) ? group.permissions : [];
+                            return total + options.length;
+                          }, 0); %>
+                          <li class="permission-selector-item">
+                            <button
+                              type="button"
+                              class="permission-choice <%= categoryIndex === 0 ? 'is-active' : '' %>"
+                              data-permission-category="<%= category.key %>"
+                              aria-pressed="<%= categoryIndex === 0 ? 'true' : 'false' %>"
+                              aria-controls="permission-panel-<%= role.id %>-<%= category.key %>"
+                            >
+                              <span class="permission-choice-name"><%= category.label %></span>
+                              <span class="badge"><%= permissionCount %> permission<%= permissionCount > 1 ? 's' : '' %></span>
+                            </button>
+                          </li>
+                        <% }) %>
+                      </ul>
+                    </aside>
+                    <div class="permission-detail" data-permission-detail>
+                      <% permissionGroups.forEach((category, categoryIndex) => { %>
+                        <% const groups = Array.isArray(category.groups) ? category.groups : []; %>
+                        <section
+                          class="permission-category permission-category-panel"
+                          id="permission-panel-<%= role.id %>-<%= category.key %>"
+                          data-permission-category-panel="<%= category.key %>"
+                          <%= categoryIndex === 0 ? '' : 'hidden' %>
+                        >
+                          <div class="permission-category-header">
+                            <h3 class="permission-category-title"><%= category.label %></h3>
+                            <% if (category.description) { %>
+                              <p class="text-sm text-muted"><%= category.description %></p>
+                            <% } %>
                           </div>
-                        </div>
+                          <% groups.forEach((group) => { %>
+                            <% const options = Array.isArray(group.permissions) ? group.permissions : []; %>
+                            <div class="permission-group">
+                              <% if (group.label) { %>
+                                <h4 class="permission-group-title"><%= group.label %></h4>
+                              <% } %>
+                              <div class="role-permissions-grid">
+                                <% options.forEach((option) => { %>
+                                  <% if (!option || typeof option.field !== 'string') { return; } %>
+                                  <% const isLockedAdminPermission = isAdministratorRole && option.field === 'is_admin'; %>
+                                  <label class="checkbox role-permission <%= option.isAggregate ? 'is-aggregate' : '' %>">
+                                    <input
+                                      type="checkbox"
+                                      name="<%= option.field %>"
+                                      value="1"
+                                      <%= role[option.field] ? 'checked' : '' %>
+                                      <%= isLockedAdminPermission ? 'disabled' : '' %>
+                                    />
+                                    <% if (isLockedAdminPermission) { %>
+                                      <input type="hidden" name="<%= option.field %>" value="1" />
+                                    <% } %>
+                                    <span class="permission-title">
+                                      <%= option.label %>
+                                      <% if (option.isAggregate) { %>
+                                        <span class="badge badge-aggregate" aria-label="Permission globale">Macro</span>
+                                      <% } %>
+                                    </span>
+                                    <% if (option.description) { %>
+                                      <span class="permission-description"><%= option.description %></span>
+                                    <% } %>
+                                  </label>
+                                <% }) %>
+                              </div>
+                            </div>
+                          <% }) %>
+                        </section>
                       <% }) %>
-                    </section>
-                  <% }) %>
+                    </div>
+                  </div>
                 <% } %>
               </fieldset>
               <div class="role-actions">
@@ -736,6 +772,62 @@
     };
 
     panels.forEach(initColorEditor);
+
+    const initPermissionManager = (panel) => {
+      if (!panel) {
+        return;
+      }
+      const selector = panel.querySelector('[data-permission-selector]');
+      const detail = panel.querySelector('[data-permission-detail]');
+      if (!selector || !detail) {
+        return;
+      }
+
+      const buttons = Array.from(
+        selector.querySelectorAll('[data-permission-category]'),
+      );
+      const categoryPanels = Array.from(
+        detail.querySelectorAll('[data-permission-category-panel]'),
+      );
+
+      if (!buttons.length || !categoryPanels.length) {
+        return;
+      }
+
+      const activate = (categoryKey) => {
+        let key = categoryKey;
+        const hasMatchingPanel = categoryPanels.some(
+          (section) => section.dataset.permissionCategoryPanel === key,
+        );
+        if (!key || !hasMatchingPanel) {
+          key = categoryPanels[0].dataset.permissionCategoryPanel || '';
+        }
+
+        categoryPanels.forEach((section) => {
+          section.hidden = section.dataset.permissionCategoryPanel !== key;
+        });
+
+        buttons.forEach((button) => {
+          const isActive = button.dataset.permissionCategory === key;
+          button.classList.toggle('is-active', isActive);
+          button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+      };
+
+      buttons.forEach((button) => {
+        button.addEventListener('click', () => {
+          activate(button.dataset.permissionCategory || '');
+        });
+      });
+
+      const initiallyActive =
+        buttons.find((button) => button.classList.contains('is-active'))?.dataset
+          .permissionCategory || buttons[0].dataset.permissionCategory;
+
+      activate(initiallyActive);
+    };
+
+    panels.forEach(initPermissionManager);
 
     const createRoleButton = manager.querySelector('[data-action="create-role"]');
 


### PR DESCRIPTION
## Summary
- add a dedicated permission category selector to the admin roles page
- display permissions in a right-hand detail panel with updated styling
- apply new styles for the selector, including responsive adjustments

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68dda1bad734832192000be7bde649b1