### PR TITLE
Use snowflake identifiers for default roles

### DIFF
--- a/utils/defaultRoles.js
+++ b/utils/defaultRoles.js
@@ -1,0 +1,114 @@
+export const DEFAULT_ROLE_KEYS = Object.freeze({
+  EVERYONE: "everyone",
+  ADMINISTRATOR: "administrator",
+});
+
+const baseDefinitions = [
+  {
+    key: DEFAULT_ROLE_KEYS.EVERYONE,
+    snowflake: "231903782071590912",
+    name: "Everyone",
+    description: "Permissions de base accordées à tous les visiteurs.",
+    color: null,
+    isSystem: true,
+    grantAllPermissions: false,
+    permissionOverrides: {
+      can_comment: true,
+      can_submit_pages: true,
+    },
+  },
+  {
+    key: DEFAULT_ROLE_KEYS.ADMINISTRATOR,
+    snowflake: "231903829383921664",
+    name: "Administrateur",
+    description: "Accès complet à toutes les fonctionnalités.",
+    color: "#DC2626",
+    isSystem: true,
+    grantAllPermissions: true,
+    permissionOverrides: {},
+  },
+];
+
+export const DEFAULT_ROLE_DEFINITIONS = Object.freeze(
+  baseDefinitions.map((role) =>
+    Object.freeze({
+      ...role,
+      permissionOverrides: Object.freeze({ ...role.permissionOverrides }),
+    }),
+  ),
+);
+
+export const DEFAULT_ROLE_SNOWFLAKES = Object.freeze(
+  DEFAULT_ROLE_DEFINITIONS.reduce((acc, role) => {
+    acc[role.key] = role.snowflake;
+    return acc;
+  }, {}),
+);
+
+export const EVERYONE_ROLE_SNOWFLAKE =
+  DEFAULT_ROLE_SNOWFLAKES[DEFAULT_ROLE_KEYS.EVERYONE];
+export const ADMINISTRATOR_ROLE_SNOWFLAKE =
+  DEFAULT_ROLE_SNOWFLAKES[DEFAULT_ROLE_KEYS.ADMINISTRATOR];
+
+export function getDefaultRoleDefinition(key) {
+  return (
+    DEFAULT_ROLE_DEFINITIONS.find((definition) => definition.key === key) || null
+  );
+}
+
+export function normalizeRoleIdentifier(role) {
+  if (role == null) {
+    return null;
+  }
+  if (typeof role === "string" || typeof role === "number" || typeof role === "bigint") {
+    const value = String(role).trim();
+    return value || null;
+  }
+  if (typeof role === "object") {
+    const candidate =
+      role.snowflake_id ?? role.snowflakeId ?? role.id ?? role.role_id ?? null;
+    if (candidate == null) {
+      return null;
+    }
+    const value = String(candidate).trim();
+    return value || null;
+  }
+  return null;
+}
+
+export function isDefaultRole(role, key) {
+  const expected = DEFAULT_ROLE_SNOWFLAKES[key];
+  if (!expected) {
+    return false;
+  }
+  const identifier = normalizeRoleIdentifier(role);
+  if (!identifier) {
+    return false;
+  }
+  return identifier === expected;
+}
+
+export function applyDefaultRoleMetadata(role) {
+  if (!role || typeof role !== "object") {
+    return role;
+  }
+  const identifier = normalizeRoleIdentifier(role);
+  const metadata = {
+    isEveryone: identifier === EVERYONE_ROLE_SNOWFLAKE,
+    isAdministrator: identifier === ADMINISTRATOR_ROLE_SNOWFLAKE,
+  };
+  if (
+    role.isEveryone === metadata.isEveryone &&
+    role.isAdministrator === metadata.isAdministrator
+  ) {
+    return role;
+  }
+  return { ...role, ...metadata };
+}
+
+export function annotateDefaultRoles(roles = []) {
+  if (!Array.isArray(roles)) {
+    return [];
+  }
+  return roles.map((role) => applyDefaultRoleMetadata(role));
+}

--- a/views/admin/roles.ejs
+++ b/views/admin/roles.ejs
@@ -12,6 +12,8 @@
   <% if (!roles || !roles.length) { %>
     <p class="card">Aucun rôle défini pour le moment.</p>
   <% } else { %>
+    <% const everyoneRole = roles.find((role) => role.isEveryone); %>
+    <% const everyoneRoleName = everyoneRole ? everyoneRole.name : 'Everyone'; %>
     <aside class="role-sidebar card" aria-label="Rôles disponibles">
       <div class="role-sidebar-header">
         <div class="role-sidebar-header-text">
@@ -57,7 +59,7 @@
           <% const roleColorPresentation = role.colorPresentation; %>
           <% const roleColorValues = Array.isArray(roleColorScheme && roleColorScheme.colors) ? roleColorScheme.colors : []; %>
           <% const roleColorMode = roleColorScheme ? roleColorScheme.mode : ''; %>
-          <% const isAdministratorRole = (role.name || '').toLowerCase() === 'administrateur'; %>
+          <% const isAdministratorRole = Boolean(role.isAdministrator); %>
           <div class="role-editor">
             <div class="role-summary">
               <div class="role-summary-header">
@@ -82,7 +84,7 @@
               <% if (role.is_system) { %>
                 <p class="text-xs text-muted">Rôle système protégé</p>
               <% } %>
-              <% if (!role.is_system && (role.name || '').toLowerCase() !== 'everyone') { %>
+              <% if (!role.is_system && !role.isEveryone) { %>
                 <div class="role-summary-footer">
                   <% if ((role.userCount || 0) === 0) { %>
                     <form method="post" action="/admin/roles/<%= role.id %>" aria-label="Supprimer le rôle <%= role.name %>">
@@ -92,11 +94,11 @@
                   <% } else { %>
                     <p class="text-sm text-muted">
                       Ce rôle est actuellement attribué à <strong><%= role.userCount %></strong>
-                      utilisateur<%= role.userCount > 1 ? 's' : '' %>. Réassignez-les vers Everyone pour pouvoir supprimer ce rôle.
+                      utilisateur<%= role.userCount > 1 ? 's' : '' %>. Réassignez-les vers <%= everyoneRoleName %> pour pouvoir supprimer ce rôle.
                     </p>
-                    <form method="post" action="/admin/roles/<%= role.id %>" class="role-reassign-form" aria-label="Réassigner les utilisateurs de <%= role.name %> vers Everyone">
+                    <form method="post" action="/admin/roles/<%= role.id %>" class="role-reassign-form" aria-label="Réassigner les utilisateurs de <%= role.name %> vers <%= everyoneRoleName %>">
                       <input type="hidden" name="_action" value="reassign_to_everyone" />
-                      <button class="btn secondary" type="submit" data-icon="🔁">Réassigner tous les utilisateurs vers Everyone</button>
+                      <button class="btn secondary" type="submit" data-icon="🔁">Réassigner tous les utilisateurs vers <%= everyoneRoleName %></button>
                     </form>
                   <% } %>
                 </div>


### PR DESCRIPTION
## Summary
- define default role metadata with stable snowflake identifiers and helper utilities
- seed and synchronize default roles using those snowflakes and update role service to cache Everyone by ID
- update admin role management flows and views to rely on snowflake metadata instead of hard-coded role names

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68dda924ef988321832489ab08846d12