### PR TITLE
Add JSON data portability tooling to admin area

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -536,6 +536,12 @@ textarea {
   max-width: 100%;
 }
 
+input[type="checkbox"],
+input[type="radio"] {
+  width: auto;
+  margin-right: 0.5rem;
+}
+
 textarea {
   resize: vertical;
 }
@@ -800,6 +806,49 @@ textarea {
 .alert.success {
   border-color: #a3d6a4;
   background: #eff8f2;
+}
+
+.alert.warning {
+  border-color: #f6c177;
+  background: #fff7e8;
+}
+
+.data-type-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.data-type-item {
+  list-style: none;
+}
+
+.data-type-option {
+  display: block;
+  font-weight: 400;
+}
+
+.data-type-option .option-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.data-type-option .option-description {
+  margin-left: 1.75rem;
+  color: #52606d;
+  font-size: 0.9rem;
+}
+
+.data-scope-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 400;
+  margin-bottom: 0.5rem;
 }
 
 

--- a/utils/dataPortability.js
+++ b/utils/dataPortability.js
@@ -1,0 +1,272 @@
+import { all, run } from "../db.js";
+
+export const DATA_PORTABILITY_TYPES = Object.freeze([
+  {
+    key: "settings",
+    label: "Paramètres du site",
+    description:
+      "Configuration générale du wiki (nom, logo, intégrations).",
+    tables: [
+      { name: "settings", orderBy: "id ASC" },
+    ],
+  },
+  {
+    key: "accounts",
+    label: "Comptes et rôles",
+    description:
+      "Rôles, permissions et comptes utilisateurs associés.",
+    tables: [
+      { name: "roles", orderBy: "position DESC, id ASC" },
+      { name: "users", orderBy: "id ASC" },
+    ],
+  },
+  {
+    key: "pages",
+    label: "Pages et révisions",
+    description:
+      "Contenu publié, corbeille et historique des révisions.",
+    tables: [
+      { name: "pages", orderBy: "id ASC" },
+      { name: "page_revisions", orderBy: "page_id ASC, revision ASC" },
+      { name: "deleted_pages", orderBy: "id ASC" },
+    ],
+  },
+  {
+    key: "taxonomy",
+    label: "Étiquettes",
+    description: "Tags disponibles et associations avec les pages.",
+    tables: [
+      { name: "tags", orderBy: "id ASC" },
+      { name: "page_tags", orderBy: "page_id ASC, tag_id ASC" },
+    ],
+  },
+  {
+    key: "feedback",
+    label: "Commentaires et likes",
+    description: "Interactions des visiteurs avec les contenus.",
+    tables: [
+      { name: "comments", orderBy: "id ASC" },
+      { name: "likes", orderBy: "id ASC" },
+    ],
+  },
+  {
+    key: "submissions",
+    label: "Contributions",
+    description:
+      "Brouillons et propositions de pages en attente ou traitées.",
+    tables: [{ name: "page_submissions", orderBy: "id ASC" }],
+  },
+  {
+    key: "moderation",
+    label: "Modération IP",
+    description:
+      "Blocages IP, appels de déban et profils IP enrichis.",
+    tables: [
+      { name: "ip_bans", orderBy: "id ASC" },
+      { name: "ban_appeals", orderBy: "id ASC" },
+      { name: "ip_profiles", orderBy: "id ASC" },
+    ],
+  },
+  {
+    key: "events",
+    label: "Journal d'événements",
+    description: "Historique des notifications envoyées aux webhooks.",
+    tables: [{ name: "event_logs", orderBy: "id ASC" }],
+  },
+  {
+    key: "uploads",
+    label: "Fichiers téléversés",
+    description:
+      "Métadonnées des fichiers présents dans la bibliothèque (hors contenu binaire).",
+    tables: [{ name: "uploads", orderBy: "created_at ASC" }],
+  },
+]);
+
+const DATA_PORTABILITY_TYPE_MAP = DATA_PORTABILITY_TYPES.reduce((acc, type) => {
+  acc.set(type.key, type);
+  return acc;
+}, new Map());
+
+function sanitizeRow(row) {
+  if (!row || typeof row !== "object") {
+    return {};
+  }
+  return Object.entries(row).reduce((acc, [key, value]) => {
+    if (value !== undefined) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+}
+
+function uniqueKeys(keys = []) {
+  const seen = new Set();
+  const ordered = [];
+  for (const key of keys) {
+    if (!key || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    ordered.push(key);
+  }
+  return ordered;
+}
+
+function getOrderedTypes(requestedKeys = []) {
+  const allKeys = DATA_PORTABILITY_TYPES.map((type) => type.key);
+  if (!requestedKeys || !requestedKeys.length) {
+    return allKeys;
+  }
+  const requestedSet = new Set(requestedKeys);
+  return allKeys.filter((key) => requestedSet.has(key));
+}
+
+async function exportTable({ name, orderBy = null }) {
+  const orderClause = orderBy ? ` ORDER BY ${orderBy}` : "";
+  const rows = await all(`SELECT * FROM ${name}${orderClause}`);
+  return rows.map((row) => sanitizeRow(row));
+}
+
+async function exportType(definition) {
+  const tables = {};
+  for (const table of definition.tables || []) {
+    tables[table.name] = await exportTable(table);
+  }
+  return { tables };
+}
+
+function getDeclaredTypes(payload) {
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+  const availableKeys = new Set(DATA_PORTABILITY_TYPES.map((type) => type.key));
+  const explicitTypes = Array.isArray(payload.types)
+    ? payload.types.filter((key) => availableKeys.has(key))
+    : [];
+  if (explicitTypes.length) {
+    return uniqueKeys(explicitTypes);
+  }
+  const data = payload.data && typeof payload.data === "object" ? payload.data : {};
+  return uniqueKeys(
+    Object.keys(data).filter((key) => availableKeys.has(key)),
+  );
+}
+
+async function importType(definition, dataset = {}) {
+  if (!definition || !dataset || typeof dataset !== "object") {
+    return;
+  }
+  const tables = dataset.tables && typeof dataset.tables === "object"
+    ? dataset.tables
+    : {};
+  for (const table of definition.tables || []) {
+    const rows = tables[table.name];
+    if (!Array.isArray(rows)) {
+      continue;
+    }
+    await run(`DELETE FROM ${table.name}`);
+    for (const rawRow of rows) {
+      const row = sanitizeRow(rawRow);
+      const entries = Object.entries(row);
+      if (!entries.length) {
+        continue;
+      }
+      const columns = entries.map(([column]) => column);
+      const placeholders = columns.map(() => "?").join(", ");
+      const values = entries.map(([, value]) => value);
+      await run(
+        `INSERT INTO ${table.name} (${columns.join(", ")}) VALUES (${placeholders})`,
+        values,
+      );
+    }
+  }
+}
+
+export function listDataPortabilityTypes() {
+  return DATA_PORTABILITY_TYPES.map((type) => ({
+    key: type.key,
+    label: type.label,
+    description: type.description,
+  }));
+}
+
+export function getDataPortabilityTypeKeys() {
+  return DATA_PORTABILITY_TYPES.map((type) => type.key);
+}
+
+export async function exportDataPortabilityBundle(selectedTypes = []) {
+  const orderedTypes = getOrderedTypes(selectedTypes);
+  const data = {};
+  for (const key of orderedTypes) {
+    const definition = DATA_PORTABILITY_TYPE_MAP.get(key);
+    if (!definition) {
+      continue;
+    }
+    data[key] = await exportType(definition);
+  }
+  return {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    types: orderedTypes,
+    data,
+  };
+}
+
+export async function importDataPortabilityBundle(payload, options = {}) {
+  const selected = Array.isArray(options.selectedTypes)
+    ? uniqueKeys(options.selectedTypes)
+    : [];
+  const declaredTypes = getDeclaredTypes(payload);
+  const data = payload && typeof payload === "object" && payload.data
+    ? payload.data
+    : {};
+  const candidateSet = selected.length ? new Set(selected) : new Set(declaredTypes);
+  const orderedTypes = getOrderedTypes(Array.from(candidateSet));
+  const effectiveTypes = orderedTypes.filter(
+    (key) => declaredTypes.includes(key) && data[key],
+  );
+  if (!effectiveTypes.length) {
+    return {
+      imported: [],
+      skipped: declaredTypes.filter((key) => !candidateSet.has(key)),
+      missing: selected.filter((key) => !declaredTypes.includes(key)),
+      available: declaredTypes,
+    };
+  }
+  await run("BEGIN IMMEDIATE TRANSACTION");
+  try {
+    for (const key of effectiveTypes) {
+      const definition = DATA_PORTABILITY_TYPE_MAP.get(key);
+      if (!definition) {
+        continue;
+      }
+      await importType(definition, data[key]);
+    }
+    await run("COMMIT");
+  } catch (err) {
+    await run("ROLLBACK");
+    throw err;
+  }
+  const skipped = declaredTypes.filter((key) => !effectiveTypes.includes(key));
+  const missing = selected.filter((key) => !declaredTypes.includes(key));
+  return {
+    imported: effectiveTypes,
+    skipped,
+    missing,
+    available: declaredTypes,
+  };
+}
+
+export function resolveRequestedDataTypes(rawTypes, scope = "selected") {
+  const allKeys = getDataPortabilityTypeKeys();
+  if (scope === "all") {
+    return allKeys;
+  }
+  const values = Array.isArray(rawTypes)
+    ? rawTypes
+    : typeof rawTypes === "string" && rawTypes
+      ? [rawTypes]
+      : [];
+  const allowed = new Set(allKeys);
+  return uniqueKeys(values.filter((key) => allowed.has(key)));
+}

--- a/utils/permissionDefinitions.js
+++ b/utils/permissionDefinitions.js
@@ -499,6 +499,40 @@ export const PERMISSION_CATEGORIES = [
     ],
   },
   {
+    key: "data",
+    label: "Données",
+    description: "Import et export des informations du wiki.",
+    groups: [
+      {
+        label: "Accès global",
+        permissions: [
+          {
+            field: "can_manage_data_portability",
+            label: "Gestion complète",
+            description:
+              "Autorise toutes les opérations d'import et d'export.",
+            isAggregate: true,
+          },
+        ],
+      },
+      {
+        label: "Actions détaillées",
+        permissions: [
+          {
+            field: "can_export_data",
+            label: "Exporter",
+            description: "Télécharger les jeux de données au format JSON.",
+          },
+          {
+            field: "can_import_data",
+            label: "Importer",
+            description: "Charger un fichier JSON et remplacer les données.",
+          },
+        ],
+      },
+    ],
+  },
+  {
     key: "roles",
     label: "Rôles",
     description: "Création et maintenance des rôles personnalisés.",
@@ -1083,6 +1117,7 @@ export const PERMISSION_DEPENDENCIES = {
     "can_replace_files",
     "can_delete_files",
   ],
+  can_manage_data_portability: ["can_export_data", "can_import_data"],
   can_manage_settings: [
     "can_update_general_settings",
     "can_manage_integrations",

--- a/views/admin/data_portability.ejs
+++ b/views/admin/data_portability.ejs
@@ -1,0 +1,93 @@
+<h1>Import / export des données</h1>
+
+<section class="card">
+  <h2>Exporter des données</h2>
+  <p class="text-muted">
+    Téléchargez un fichier JSON contenant les jeux de données sélectionnés. Celui-ci peut être
+    réimporté plus tard sur une autre instance du wiki.
+  </p>
+  <% if (!canExportData) { %>
+    <div class="alert warning">Vous n'avez pas l'autorisation d'exporter des données.</div>
+  <% } %>
+  <form method="post" action="/admin/data/export">
+    <fieldset class="field">
+      <legend>Jeux de données disponibles</legend>
+      <ul class="data-type-list">
+        <% dataTypes.forEach((type) => { %>
+          <li class="data-type-item">
+            <label class="data-type-option">
+              <span class="option-header">
+                <input type="checkbox" name="types" value="<%= type.key %>" <%= canExportData ? '' : 'disabled' %> />
+                <span class="option-title"><%= type.label %></span>
+              </span>
+              <% if (type.description) { %>
+                <span class="option-description"><%= type.description %></span>
+              <% } %>
+            </label>
+          </li>
+        <% }); %>
+      </ul>
+    </fieldset>
+    <fieldset class="field">
+      <legend>Portée</legend>
+      <label class="data-scope-option">
+        <input type="radio" name="scope" value="selected" checked <%= canExportData ? '' : 'disabled' %> />
+        Exporter uniquement les jeux cochés
+      </label>
+      <label class="data-scope-option">
+        <input type="radio" name="scope" value="all" <%= canExportData ? '' : 'disabled' %> />
+        Exporter tous les jeux disponibles
+      </label>
+    </fieldset>
+    <button class="btn" type="submit" data-icon="⬇️" <%= canExportData ? '' : 'disabled' %>>Télécharger le JSON</button>
+  </form>
+</section>
+
+<section class="card">
+  <h2>Importer des données</h2>
+  <p class="text-muted">
+    Chargez un fichier exporté précédemment pour restaurer un ou plusieurs jeux de données. Les tables
+    sélectionnées seront écrasées par le contenu du fichier.
+  </p>
+  <% if (!canImportData) { %>
+    <div class="alert warning">Vous n'avez pas l'autorisation d'importer des données.</div>
+  <% } %>
+  <form method="post" action="/admin/data/import" enctype="multipart/form-data">
+    <div class="field">
+      <label for="dataFile">Fichier JSON</label>
+      <input id="dataFile" type="file" name="dataFile" accept="application/json" <%= canImportData ? '' : 'disabled' %> required />
+      <span class="field-hint">Seuls les exports générés depuis cette interface sont pris en charge.</span>
+    </div>
+    <fieldset class="field">
+      <legend>Portée</legend>
+      <label class="data-scope-option">
+        <input type="radio" name="scope" value="selected" checked <%= canImportData ? '' : 'disabled' %> />
+        Importer uniquement les jeux cochés ci-dessous
+      </label>
+      <label class="data-scope-option">
+        <input type="radio" name="scope" value="all" <%= canImportData ? '' : 'disabled' %> />
+        Importer tous les jeux présents dans le fichier
+      </label>
+    </fieldset>
+    <fieldset class="field">
+      <legend>Jeux de données à importer</legend>
+      <ul class="data-type-list">
+        <% dataTypes.forEach((type) => { %>
+          <li class="data-type-item">
+            <label class="data-type-option">
+              <span class="option-header">
+                <input type="checkbox" name="types" value="<%= type.key %>" <%= canImportData ? '' : 'disabled' %> />
+                <span class="option-title"><%= type.label %></span>
+              </span>
+              <% if (type.description) { %>
+                <span class="option-description"><%= type.description %></span>
+              <% } %>
+            </label>
+          </li>
+        <% }); %>
+      </ul>
+      <span class="field-hint">Les jeux non cochés seront ignorés lors de l'import.</span>
+    </fieldset>
+    <button class="btn" type="submit" data-icon="⬆️" <%= canImportData ? '' : 'disabled' %>>Lancer l'import</button>
+  </form>
+</section>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -173,6 +173,11 @@
       permissionFlags.can_replace_files ||
       permissionFlags.can_delete_files
     ); %>
+    <% const canManageDataPortability = !!(
+      permissionFlags.can_manage_data_portability ||
+      permissionFlags.can_export_data ||
+      permissionFlags.can_import_data
+    ); %>
     <% const canManageSettings = !!(
       permissionFlags.can_manage_settings ||
       permissionFlags.can_update_general_settings ||
@@ -228,6 +233,7 @@
       canManageLikes ||
       canManageTrash ||
       canManageUploads ||
+      canManageDataPortability ||
       canManageSettings ||
       canManageIpBans ||
       canManageIpReputation ||
@@ -305,6 +311,9 @@
       <% } %>
       <% if (canManageUploads) { %>
         <li><a href="/admin/uploads">Images</a></li>
+      <% } %>
+      <% if (canManageDataPortability) { %>
+        <li><a href="/admin/data">Données</a></li>
       <% } %>
       <% if (canManageSettings) { %>
         <li><a href="/admin/settings">Paramètres</a></li>


### PR DESCRIPTION
## Summary
- add a data portability service that can export or import predefined database groups as JSON bundles
- expose new admin routes and UI to download or upload the selected datasets with proper permission checks
- introduce dedicated permissions, navigation entry, and styling updates for the new import/export workflows

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68ddad43ceb48321a345ac88e324f394