### PR TITLE
feat: refresh wiki shell with glass sidebar layout

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1,6 +1,23 @@
 :root {
-  color-scheme: light;
+  color-scheme: dark;
   font-size: 16px;
+  --bg-gradient: radial-gradient(circle at 20% 20%, rgba(62, 91, 255, 0.25), transparent 60%),
+    radial-gradient(circle at 80% 0%, rgba(0, 212, 255, 0.35), transparent 55%),
+    linear-gradient(135deg, #060b1b 0%, #101b3a 55%, #061522 100%);
+  --glass-bg: rgba(16, 29, 54, 0.68);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --glass-hover: rgba(40, 60, 94, 0.85);
+  --shadow-glass: 0 20px 40px -25px rgba(6, 12, 30, 0.85);
+  --text-primary: #e8edff;
+  --text-muted: #9aa8c7;
+  --primary: #7a9dff;
+  --primary-strong: #4d6dff;
+  --accent: #00c9ff;
+  --accent-strong: #14ffec;
+  --danger: #ff6b8b;
+  --success: #64f58d;
+  --border-radius-lg: 24px;
+  --transition-snap: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 * {
@@ -9,159 +26,343 @@
 
 body {
   margin: 0;
-  font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   line-height: 1.6;
-  background: #ffffff;
-  color: #1f2933;
-}
-
-.user-handle {
-  font-weight: 600;
+  background: var(--bg-gradient);
+  color: var(--text-primary);
+  display: flex;
+  justify-content: center;
 }
 
 a {
-  color: #0b4cb8;
+  color: var(--accent);
   text-decoration: none;
+  position: relative;
+  transition: color 180ms var(--transition-snap), transform 180ms var(--transition-snap);
 }
 
 a:hover,
 a:focus {
-  text-decoration: underline;
+  color: var(--accent-strong);
 }
 
-.site-header,
-.site-nav,
-.site-footer {
-  background: #f5f7fa;
-  border-bottom: 1px solid #d9e2ec;
+a:active {
+  transform: scale(0.97);
 }
 
-.site-footer {
-  border-top: 1px solid #d9e2ec;
-  border-bottom: none;
+.app-shell {
+  width: min(1120px, 100%);
+  padding: clamp(1.5rem, 3vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.glass-surface {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-glass);
+  backdrop-filter: blur(26px) saturate(140%);
+  -webkit-backdrop-filter: blur(26px) saturate(140%);
+  position: relative;
+  overflow: hidden;
+}
+
+.glass-surface::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.18), transparent 55%);
+  opacity: 0;
+  transition: opacity 220ms var(--transition-snap);
+  pointer-events: none;
+}
+
+.glass-surface:hover::before {
+  opacity: 1;
 }
 
 .site-header {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  justify-content: space-between;
-  padding: 1rem 1.5rem;
+  gap: 1.25rem;
+  padding: clamp(1rem, 2vw, 1.5rem);
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .brand-link {
   font-weight: 600;
-  font-size: 1.2rem;
+  font-size: 1.25rem;
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
-  color: inherit;
+  color: var(--text-primary);
+  letter-spacing: 0.01em;
+  transition: transform 220ms var(--transition-snap);
+}
+
+.brand-link:hover {
+  transform: translateY(-1px);
 }
 
 .brand-link img {
-  max-height: 48px;
+  max-height: 42px;
   width: auto;
+  border-radius: 12px;
+  box-shadow: 0 12px 30px -18px rgba(0, 0, 0, 0.75);
 }
 
 .search-form {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  flex: 1 1 260px;
+  gap: 0.75rem;
+  background: rgba(10, 18, 35, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 999px;
+  padding: 0.25rem 0.35rem 0.25rem 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  transition: border-color 220ms var(--transition-snap), box-shadow 220ms var(--transition-snap);
+}
+
+.search-form:focus-within {
+  border-color: rgba(122, 157, 255, 0.6);
+  box-shadow: 0 0 0 3px rgba(122, 157, 255, 0.18);
 }
 
 .search-form input[type="text"] {
   flex: 1;
-  padding: 0.45rem 0.6rem;
-  border: 1px solid #cbd2d9;
-  border-radius: 4px;
+  min-width: 120px;
+  padding: 0.45rem 0.5rem;
+  font: inherit;
+  color: var(--text-primary);
+  background: transparent;
+  border: none;
+  outline: none;
+}
+
+.search-form input::placeholder {
+  color: rgba(232, 237, 255, 0.4);
 }
 
 .auth-links {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 0.75rem;
+  justify-self: end;
 }
 
-.site-nav {
-  padding: 0.75rem 1.5rem;
+.auth-links form {
+  margin: 0;
+}
+
+.nav-toggle {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(10, 18, 35, 0.6);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  cursor: pointer;
+  transition: transform 200ms var(--transition-snap), box-shadow 200ms var(--transition-snap), border-color 200ms var(--transition-snap);
+}
+
+.nav-toggle:hover {
+  transform: translateY(-2px);
+  border-color: rgba(122, 157, 255, 0.65);
+  box-shadow: 0 10px 25px -18px rgba(122, 157, 255, 0.65);
+}
+
+.nav-toggle:active {
+  transform: scale(0.92);
+}
+
+.nav-toggle-bar {
+  display: block;
+  width: 18px;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--text-primary);
+  transition: transform 220ms var(--transition-snap), opacity 220ms var(--transition-snap);
+}
+
+html.drawer-open .nav-toggle-bar:nth-child(1) {
+  transform: translateY(5px) rotate(45deg);
+}
+
+html.drawer-open .nav-toggle-bar:nth-child(2) {
+  opacity: 0;
+}
+
+html.drawer-open .nav-toggle-bar:nth-child(3) {
+  transform: translateY(-5px) rotate(-45deg);
+}
+
+.shell-body {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 1.5rem;
+  position: relative;
+}
+
+.site-sidebar {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  position: sticky;
+  top: 1.5rem;
+  max-height: calc(100vh - 3rem);
+  overflow-y: auto;
+  scrollbar-width: thin;
 }
 
 .site-nav ul {
-  margin: 0;
-  padding: 0;
   list-style: none;
+  padding: 0;
+  margin: 0;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem 1.25rem;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .site-nav a {
-  color: inherit;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 14px;
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.02);
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  transition: transform 200ms var(--transition-snap), box-shadow 220ms var(--transition-snap), background 220ms var(--transition-snap);
+}
+
+.site-nav a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(122, 157, 255, 0.35), rgba(20, 255, 236, 0.25));
+  opacity: 0;
+  transition: opacity 220ms var(--transition-snap);
+  z-index: -1;
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+  transform: translateX(4px);
+  box-shadow: 0 14px 26px -20px rgba(20, 255, 236, 0.45);
+}
+
+.site-nav a:hover::after,
+.site-nav a:focus::after {
+  opacity: 1;
+}
+
+.site-nav a:active {
+  transform: translateX(2px) scale(0.98);
+}
+
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 8, 20, 0.55);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 200ms ease;
+  z-index: 8;
+}
+
+html.drawer-open .drawer-overlay {
+  opacity: 1;
+  visibility: visible;
+}
+
+.content-area {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  position: relative;
 }
 
 .page-content {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 1.5rem;
-  width: 100%;
+  flex: 1;
+  padding: clamp(1.25rem, 2vw, 2rem);
+  border-radius: var(--border-radius-lg);
+  background: rgba(10, 18, 35, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 .site-footer {
-  padding: 1.5rem;
+  margin-top: auto;
+  padding: 1.1rem 1.5rem;
   text-align: center;
-  background: #f5f7fa;
+  color: var(--text-muted);
+  font-size: 0.9rem;
 }
 
 .btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.4rem 0.85rem;
-  border: 1px solid #cbd2d9;
-  border-radius: 4px;
-  background: #f1f5f9;
-  color: inherit;
-  cursor: pointer;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(122, 157, 255, 0.35);
+  background: linear-gradient(135deg, rgba(122, 157, 255, 0.25), rgba(20, 255, 236, 0.15));
+  color: var(--text-primary);
   font: inherit;
-  text-decoration: none;
+  cursor: pointer;
+  transition: transform 200ms var(--transition-snap), box-shadow 220ms var(--transition-snap), background 220ms var(--transition-snap);
 }
 
 .btn:hover,
 .btn:focus {
-  background: #e1e8f0;
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px -22px rgba(20, 255, 236, 0.6);
+  background: linear-gradient(135deg, rgba(122, 157, 255, 0.35), rgba(20, 255, 236, 0.3));
+}
+
+.btn:active {
+  transform: scale(0.95);
 }
 
 .btn.success {
-  background: #e7f5e9;
-  border-color: #a3d6a4;
+  border-color: rgba(100, 245, 141, 0.45);
+  background: linear-gradient(135deg, rgba(100, 245, 141, 0.3), rgba(20, 255, 236, 0.2));
 }
 
 .btn.secondary {
-  background: #e6ecf8;
-  border-color: #b8c6eb;
+  border-color: rgba(122, 157, 255, 0.45);
+  background: linear-gradient(135deg, rgba(122, 157, 255, 0.25), rgba(91, 125, 255, 0.25));
 }
 
 .btn.danger {
-  background: #faeaea;
-  border-color: #e5a6aa;
-}
-
-.btn.like,
-.btn.unlike {
-  background: #fdf4f6;
-  border-color: #f0c4ce;
-}
-
-.btn.copy {
-  background: #f1f5f9;
+  border-color: rgba(255, 107, 139, 0.55);
+  background: linear-gradient(135deg, rgba(255, 107, 139, 0.35), rgba(122, 157, 255, 0.15));
 }
 
 .btn[aria-disabled="true"],
 .btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.user-handle {
+  font-weight: 600;
 }
 
 .sr-only {
@@ -177,536 +378,43 @@ a:focus {
 }
 
 .card {
-  border: 1px solid #d9e2ec;
-  border-radius: 6px;
-  padding: 1rem;
-  background: #ffffff;
-  margin-bottom: 1.25rem;
+  border-radius: 20px;
+  padding: 1.5rem;
+  background: rgba(10, 18, 35, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow-glass);
+  margin-bottom: 1.5rem;
 }
 
 .field-hint {
   display: block;
-  margin: 0.25rem 0 0.75rem;
-  color: #52606d;
+  margin: 0.35rem 0 0.9rem;
+  color: var(--text-muted);
   font-size: 0.85rem;
-}
-
-.changelog-card .card-subtitle {
-  margin: 0;
-  color: #52606d;
-}
-
-.changelog-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.changelog-controls .control-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  min-width: 160px;
-}
-
-.changelog-controls select {
-  padding: 0.35rem 0.5rem;
-  border: 1px solid #cbd2d9;
-  border-radius: 4px;
-  font: inherit;
-}
-
-.changelog-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.changelog-item {
-  border-top: 1px solid #e4e7eb;
-  padding-top: 1.25rem;
-}
-
-.changelog-item:first-child {
-  border-top: none;
-  padding-top: 0;
-}
-
-.changelog-item-header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 1rem;
-  color: #52606d;
-  font-size: 0.9rem;
-}
-
-.changelog-type {
-  font-weight: 600;
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.05em;
-  color: #829ab1;
-}
-
-.changelog-title {
-  margin: 0.35rem 0;
-  font-size: 1.1rem;
-}
-
-.changelog-title a {
-  color: inherit;
-}
-
-.changelog-meta {
-  margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  color: #52606d;
-  font-size: 0.9rem;
-}
-
-.changelog-sha {
-  font-family: "Fira Code", "Courier New", monospace;
-}
-
-.changelog-state {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0.1rem 0.4rem;
-  border-radius: 4px;
-  border: 1px solid transparent;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.changelog-state-open {
-  background: #e3f9e5;
-  border-color: #a3d6a4;
-  color: #036b26;
-}
-
-.changelog-state-closed {
-  background: #fde8e8;
-  border-color: #f8b4b4;
-  color: #c81e1e;
-}
-
-.changelog-state-merged {
-  background: #e8e1ff;
-  border-color: #c4b5f6;
-  color: #5f3dc4;
-}
-
-.changelog-state-draft {
-  background: #f0f4f8;
-  border-color: #cbd2d9;
-  color: #52606d;
-}
-
-.changelog-message {
-  margin-top: 0.75rem;
-}
-
-.changelog-message summary {
-  cursor: pointer;
-  font-weight: 600;
-}
-
-.changelog-message pre {
-  margin: 0.5rem 0 0 0;
-  padding: 0.75rem;
-  background: #f1f5f9;
-  border-radius: 6px;
-  overflow: auto;
-}
-
-.changelog-summary {
-  margin-top: 0.75rem;
-  white-space: pre-wrap;
-}
-
-.changelog-pagination {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  margin-top: 1.5rem;
-}
-
-.changelog-pagination .pager {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.page-indicator {
-  font-weight: 600;
-}
-
-.rate-limit {
-  margin-top: 1rem;
-  color: #52606d;
-  font-size: 0.85rem;
-}
-
-.empty-state {
-  color: #52606d;
-  font-style: italic;
-}
-
-@media (max-width: 640px) {
-  .changelog-item-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .changelog-controls {
-    flex-direction: column;
-    align-items: stretch;
-  }
-}
-
-.card-header {
-  margin-bottom: 0.75rem;
-}
-
-.card-title {
-  margin: 0 0 0.25rem 0;
-}
-
-.card-badge {
-  display: inline-block;
-  padding: 0.1rem 0.5rem;
-  background: #edf2ff;
-  border: 1px solid #c3d1ff;
-  border-radius: 999px;
-  font-size: 0.85rem;
-}
-
-.card-footer {
-  margin-top: 1rem;
-}
-
-.home-hero,
-.home-section {
-  margin-bottom: 2rem;
-}
-
-.hero-eyebrow {
-  text-transform: uppercase;
-  font-size: 0.8rem;
-  letter-spacing: 0.08em;
-  color: #52606d;
-}
-
-.article-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
-}
-
-.hero-intro h1,
-.hero-intro .hero-title {
-  margin-top: 0;
-}
-
-.hero-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.75rem;
-}
-
-.hero-stats {
-  display: grid;
-  gap: 0.75rem;
-  margin-top: 1.5rem;
-}
-
-.hero-stat {
-  border: 1px solid #d9e2ec;
-  border-radius: 6px;
-  padding: 0.75rem;
-}
-
-.section-heading {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.section-heading h2 {
-  margin: 0;
-}
-
-.section-heading-text p {
-  margin: 0.35rem 0 0 0;
-  color: #52606d;
-}
-
-.page-stats,
-.card-actions,
-.actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
-  margin-top: 0.75rem;
-}
-
-.tags-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.75rem;
-}
-
-.tag {
-  display: inline-block;
-  padding: 0.15rem 0.55rem;
-  border: 1px solid #cbd2d9;
-  border-radius: 999px;
-  background: #f1f5f9;
-  font-size: 0.85rem;
-}
-
-.pagination {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-  margin: 2rem 0;
-}
-
-.pagination-status {
-  font-weight: 600;
-}
-
-.table-responsive {
-  width: 100%;
-  overflow-x: auto;
-}
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-bottom: 1rem;
-}
-
-th,
-td {
-  padding: 0.6rem;
-  border: 1px solid #d9e2ec;
-  text-align: left;
-}
-
-thead {
-  background: #f5f7fa;
-}
-
-form {
-  display: block;
-}
-
-label {
-  display: block;
-  margin-bottom: 0.35rem;
-  font-weight: 600;
-}
-
-input,
-select,
-textarea {
-  font: inherit;
-  padding: 0.45rem 0.6rem;
-  border: 1px solid #cbd2d9;
-  border-radius: 4px;
-  width: 100%;
-  max-width: 100%;
-}
-
-textarea {
-  resize: vertical;
-}
-
-.field {
-  margin-bottom: 1rem;
-}
-
-.text-muted {
-  color: #52606d;
-}
-
-.text-required {
-  color: #c81e1e;
-}
-
-.comment-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.comment {
-  border-top: 1px solid #d9e2ec;
-  padding: 1rem 0;
-}
-
-.comment:first-child {
-  border-top: none;
-}
-
-.comment-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  font-size: 0.9rem;
-  color: #52606d;
-}
-
-.comment-body {
-  margin-top: 0.5rem;
-}
-
-.comment-actions {
-  margin-top: 0.75rem;
-  display: flex;
-  gap: 0.5rem;
-}
-
-.comment-author--admin {
-  color: #0f609b;
-}
-
-.comment-author-badge {
-  font-size: 0.8rem;
-}
-
-.comment-empty {
-  font-style: italic;
-  color: #52606d;
-}
-
-.page-header {
-  margin-bottom: 1.5rem;
-}
-
-.page-header .meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  color: #52606d;
-  font-size: 0.95rem;
-}
-
-.page-title {
-  margin: 0;
-}
-
-.table-footer {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 1rem;
-}
-
-.table-footer .pager {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.stats-live-card .live-stats-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.stats-live-card .live-stats-header > div:first-child {
-  flex: 1 1 240px;
-}
-
-.stats-live-card .live-stats-refresh,
-.stats-live-card .live-stats-per-page {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.stats-live-card select {
-  width: auto;
-}
-
-.stats-live-card .live-stats-refresh select,
-.stats-live-card .live-stats-per-page select {
-  min-width: 140px;
-}
-
-.stats-live-card .live-stats-empty {
-  margin: 0 0 1rem 0;
-  color: #52606d;
-}
-
-.stats-live-card [data-live-status] {
-  margin-top: 0.35rem;
-  font-size: 0.85rem;
-}
-
-.stats-live-card [data-live-status].live-stats-status-error {
-  color: #c81e1e;
-}
-
-@media (max-width: 640px) {
-  .stats-live-card .live-stats-refresh,
-  .stats-live-card .live-stats-per-page {
-    width: 100%;
-    justify-content: space-between;
-  }
-}
-
-.honeypot {
-  display: none;
 }
 
 .notification-layer {
   position: fixed;
-  top: 1rem;
-  right: 1rem;
+  top: clamp(1.5rem, 3vw, 3rem);
+  right: clamp(1.5rem, 3vw, 3rem);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  z-index: 1000;
+  z-index: 9;
 }
 
 .notification {
   min-width: 240px;
-  padding: 0.75rem 0.85rem;
-  border: 1px solid #d9e2ec;
-  border-radius: 6px;
-  background: #ffffff;
-  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.12);
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
+  max-width: 320px;
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  background: rgba(15, 27, 50, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 34px -24px rgba(0, 0, 0, 0.9);
+  color: var(--text-primary);
   opacity: 0;
-  transform: translateY(-8px);
-  transition:
-    opacity 0.2s ease,
-    transform 0.2s ease;
+  transform: translateY(-6px);
+  transition: opacity 220ms ease, transform 220ms ease;
 }
 
 .notification.show {
@@ -714,761 +422,117 @@ textarea {
   transform: translateY(0);
 }
 
-.notification.info {
-  border-color: #9fb3c8;
-}
-
 .notification.success {
-  border-color: #8bbd8b;
-  background: #eff8f2;
+  border-color: rgba(100, 245, 141, 0.45);
 }
 
-.notification.error {
-  border-color: #e5a6aa;
-  background: #fdecec;
+.notification.error,
+.notification.danger {
+  border-color: rgba(255, 107, 139, 0.55);
 }
 
 .notification.warning {
-  border-color: #f6c177;
-  background: #fff7e8;
+  border-color: rgba(255, 198, 73, 0.55);
 }
 
-.notification-body {
-  flex: 1;
-}
-
-.notification-title {
-  font-weight: 600;
-  margin-bottom: 0.25rem;
-}
-
-.notification-message {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.notification-action {
-  font-weight: 600;
+.notification-icon {
+  font-size: 1.25rem;
 }
 
 .notification-close {
-  background: none;
+  background: transparent;
   border: none;
+  color: inherit;
   font-size: 1rem;
   cursor: pointer;
+  padding: 0.25rem;
 }
 
-.prose {
-  line-height: 1.7;
-}
-
-.prose h1,
-.prose h2,
-.prose h3,
-.prose h4,
-.prose h5,
-.prose h6 {
-  margin-top: 1.5rem;
-  margin-bottom: 0.75rem;
-}
-
-.prose p,
-.prose ul,
-.prose ol {
-  margin-bottom: 1rem;
-}
-
-.prose ul,
-.prose ol {
-  padding-left: 1.25rem;
-}
-
-.alert {
-  border: 1px solid #d9e2ec;
-  border-radius: 6px;
-  background: #f5f7fa;
-  padding: 0.75rem 1rem;
-  margin-bottom: 1rem;
-}
-
-.alert.error {
-  border-color: #e5a6aa;
-  background: #fdecec;
-}
-
-.alert.success {
-  border-color: #a3d6a4;
-  background: #eff8f2;
-}
-
-
-.role-manager {
-  display: grid;
-  grid-template-columns: minmax(220px, 280px) 1fr;
-  gap: 1.5rem;
-  align-items: start;
-}
-
-.role-sidebar {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.role-sidebar-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 0.75rem;
-}
-
-.role-sidebar-header-text {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.role-sidebar-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  justify-content: flex-end;
-}
-
-.role-selector {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.role-selector-item {
-  margin: 0;
-  cursor: grab;
-  border-radius: 6px;
-}
-
-.role-selector-item:active {
-  cursor: grabbing;
-}
-
-.role-selector-item.is-dragging {
-  opacity: 0.6;
-}
-
-.role-selector-item.is-dragging .role-choice {
-  pointer-events: none;
-}
-
-.role-selector li {
-  margin: 0;
-}
-
-.role-choice {
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.65rem 0.75rem;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  background: #f5f7fa;
-  color: inherit;
-  cursor: pointer;
-  font: inherit;
-  text-align: left;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.role-choice:hover,
-.role-choice:focus {
-  background: #edf2f7;
-  outline: none;
-}
-
-.role-choice.is-active {
-  border-color: #4c6ef5;
-  background: #eef2ff;
-  box-shadow: 0 0 0 2px rgba(76, 110, 245, 0.15);
-}
-
-.role-choice .badge {
-  margin-left: auto;
-}
-
-.role-detail {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.role-detail-panel {
-  margin: 0;
-}
-
-.role-detail-panel[hidden] {
-  display: none;
-}
-
-.role-editor {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5rem;
-  align-items: flex-start;
-}
-
-.role-editor .role-summary {
-  flex: 0 0 260px;
-  max-width: 320px;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.role-editor .form-field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.role-editor .field-label {
-  font-size: 0.9rem;
-  color: #52606d;
-}
-
-.role-editor .role-permissions-column {
-  flex: 1 1 320px;
-  min-width: 260px;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.role-permissions {
-  margin: 0;
-  padding: 0;
-  border: none;
-}
-
-.role-permissions legend {
-  font-weight: 600;
-  margin-bottom: 0.75rem;
-}
-
-.permission-manager {
-  display: grid;
-  grid-template-columns: minmax(220px, 260px) 1fr;
-  gap: 1.5rem;
-  align-items: start;
-}
-
-.permission-sidebar {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.permission-sidebar-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.permission-selector {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.permission-selector-item {
-  margin: 0;
-}
-
-.permission-choice {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.65rem 0.75rem;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  background: #f5f7fa;
-  color: inherit;
-  cursor: pointer;
-  font: inherit;
-  text-align: left;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.permission-choice:hover,
-.permission-choice:focus {
-  background: #edf2f7;
-  outline: none;
-}
-
-.permission-choice.is-active {
-  border-color: #4c6ef5;
-  background: #eef2ff;
-  box-shadow: 0 0 0 2px rgba(76, 110, 245, 0.15);
-}
-
-.permission-choice .badge {
-  margin-left: auto;
-}
-
-.permission-choice-name {
-  font-weight: 600;
-  color: #0b1f33;
-}
-
-.permission-detail {
-  display: flex;
-  flex-direction: column;
-  gap: 1.75rem;
-}
-
-.permission-category-panel[hidden] {
-  display: none;
-}
-
-.permission-category {
-  margin-bottom: 1.75rem;
-}
-
-.permission-category:last-of-type {
-  margin-bottom: 0;
-}
-
-.permission-category-header {
-  margin-bottom: 0.75rem;
-}
-
-.permission-category-title {
-  margin: 0;
-  font-size: 1.05rem;
-  font-weight: 600;
-  color: #0b1f33;
-}
-
-.role-permissions-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 0.75rem;
-}
-
-.permission-group + .permission-group {
-  margin-top: 1.25rem;
-}
-
-.permission-group-title {
-  margin: 0 0 0.35rem;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #64748b;
-}
-
-.role-permission {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 0.5rem;
-}
-
-.role-permission.is-aggregate {
-  border-left: 3px solid rgba(37, 99, 235, 0.45);
-  padding-left: 0.5rem;
-}
-
-.role-permission input[type='checkbox'] {
-  margin-top: 0.2rem;
-}
-
-.role-permission .permission-title {
-  display: block;
-  font-weight: 600;
-  color: #0b1f33;
-}
-
-.badge-aggregate {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.05rem 0.45rem;
-  margin-left: 0.35rem;
-  border-radius: 999px;
-  background-color: rgba(37, 99, 235, 0.12);
-  color: #1d4ed8;
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.role-permission .permission-description {
-  display: block;
-  font-size: 0.85rem;
-  color: #52606d;
-  line-height: 1.35;
-}
-
-.role-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
-  margin-top: auto;
-}
-
-@media (max-width: 900px) {
-  .permission-manager {
-    grid-template-columns: 1fr;
+@media (max-width: 1080px) {
+  .app-shell {
+    width: min(100%, 960px);
   }
 }
 
-.role-summary-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-}
-
-.role-color-preview {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  margin-top: 0.35rem;
-}
-
-.role-color-preview.is-empty .role-color-chip {
-  display: none;
-}
-
-.role-color-chip {
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: 999px;
-  border: 1px solid rgba(15, 23, 42, 0.15);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
-  background-color: var(--role-color-1, #1f2937);
-  background-image: var(--role-gradient, none);
-  background-size: var(--role-background-size, 100% 100%);
-  background-position: var(--role-background-position, 0% 50%);
-  animation: var(--role-animation, none);
-}
-
-.role-color-value {
-  font-family: monospace;
-  font-size: 0.85rem;
-  color: #52606d;
-}
-
-.role-color-visual {
-  background-color: var(--role-color-1, #1f2937);
-  background-image: var(--role-gradient, none);
-  background-size: var(--role-background-size, 100% 100%);
-  background-position: var(--role-background-position, 0% 50%);
-  animation: var(--role-animation, none);
-}
-
-.role-colored-text {
-  position: relative;
-  color: var(--role-fallback-color, var(--role-color-1, inherit));
-}
-
-.role-colored-text.role-color--gradient,
-.role-colored-text.role-color--rainbow {
-  background-image: var(--role-gradient, none);
-  background-size: var(--role-background-size, 100% 100%);
-  background-position: var(--role-background-position, 0% 50%);
-  animation: var(--role-animation, none);
-}
-
-@supports (-webkit-background-clip: text) or (background-clip: text) {
-  .role-colored-text.role-color--gradient,
-  .role-colored-text.role-color--rainbow {
-    color: transparent;
-    -webkit-background-clip: text;
-    background-clip: text;
-  }
-}
-
-.role-metadata {
-  margin-bottom: 1rem;
-}
-
-.role-color-editor {
-  display: grid;
-  gap: 0.75rem;
-  padding: 0.75rem;
-  border: 1px solid #d9e2ec;
-  border-radius: 6px;
-  background: #f8fafc;
-}
-
-.role-color-editor legend {
-  font-weight: 600;
-  margin-bottom: 0.25rem;
-}
-
-.role-color-mode select {
-  width: 100%;
-}
-
-.role-color-fields {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.role-color-collection {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.role-color-collection--single {
-  justify-content: flex-start;
-}
-
-.role-color-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.role-color-picker {
-  display: grid;
-  gap: 0.25rem;
-  justify-items: center;
-  text-align: center;
-}
-
-.role-color-picker-label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: #52606d;
-}
-
-.role-color-picker-value {
-  font-family: monospace;
-  font-size: 0.75rem;
-  color: #334155;
-}
-
-.role-color-picker input[type="color"] {
-  appearance: none;
-  -webkit-appearance: none;
-  border: none;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 999px;
-  cursor: pointer;
-  padding: 0;
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.12);
-}
-
-.role-color-picker input[type="color"]::-webkit-color-swatch-wrapper {
-  padding: 0;
-  border-radius: 999px;
-}
-
-.role-color-picker input[type="color"]::-webkit-color-swatch {
-  border: 1px solid rgba(15, 23, 42, 0.15);
-  border-radius: 999px;
-}
-
-.role-color-picker input[type="color"]::-moz-color-swatch {
-  border: 1px solid rgba(15, 23, 42, 0.15);
-  border-radius: 999px;
-}
-
-.role-color-remove {
-  border: none;
-  background: none;
-  color: #94a3b8;
-  width: 1.75rem;
-  height: 1.75rem;
-  border-radius: 999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.25rem;
-  line-height: 1;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.role-color-remove:hover,
-.role-color-remove:focus {
-  background: #fee2e2;
-  color: #ef4444;
-}
-
-.role-color-remove.is-disabled,
-.role-color-remove:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  background: none;
-  color: #cbd5e1;
-}
-
-.role-color-collection-actions {
-  display: flex;
-  justify-content: flex-start;
-}
-
-.role-color-add-button {
-  font-size: 0.85rem;
-  padding: 0.35rem 0.75rem;
-}
-
-.role-color-add-button.is-disabled,
-.role-color-add-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-.role-color-fields[hidden] {
-  display: none !important;
-}
-
-.role-color-field input[type="text"] {
-  font-family: monospace;
-  text-transform: uppercase;
-}
-
-.role-color-hint {
-  margin: 0;
-}
-
-@keyframes role-rainbow {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.15rem 0.5rem;
-  border: 1px solid #cbd2d9;
-  border-radius: 999px;
-  background: #f1f5f9;
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
-.role-summary-footer {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.role-summary-footer p {
-  margin: 0;
-}
-
-.role-summary-footer form,
-.role-reassign-form {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-@media (max-width: 900px) {
-  .role-manager {
-    grid-template-columns: 1fr;
-  }
-
-  .role-detail {
-    order: 2;
-  }
-
-  .role-sidebar {
-    order: 1;
-  }
-
-  .role-sidebar-header {
-    flex-direction: column;
+@media (max-width: 1024px) {
+  body {
     align-items: stretch;
   }
 
-  .role-sidebar-actions {
+  .app-shell {
     width: 100%;
-    justify-content: flex-start;
+    padding: clamp(1rem, 4vw, 1.75rem);
   }
 
-  .role-sidebar-actions .btn {
-    width: 100%;
-  }
-
-  .role-editor {
-    flex-direction: column;
-  }
-
-  .role-editor .role-summary,
-  .role-editor .role-permissions-column {
-    flex: 1 1 auto;
-    max-width: 100%;
-  }
-
-  .role-actions {
-    justify-content: flex-start;
-  }
-}
-
-.mt-0 {
-  margin-top: 0;
-}
-
-.mt-xs {
-  margin-top: 0.5rem;
-}
-
-@media (max-width: 720px) {
   .site-header {
-    flex-direction: column;
-    align-items: stretch;
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      "brand auth"
+      "search search";
   }
 
-  .search-form {
-    width: 100%;
+  .header-left {
+    grid-area: brand;
   }
 
   .auth-links {
-    justify-content: flex-start;
+    grid-area: auth;
+    justify-self: end;
   }
 
-  .site-nav ul {
-    flex-direction: column;
-    align-items: flex-start;
+  .search-form {
+    grid-area: search;
+    width: 100%;
   }
 
-  .page-content {
-    padding: 1.25rem;
+  .shell-body {
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .table-footer {
-    flex-direction: column;
-    align-items: flex-start;
+  .site-sidebar {
+    position: fixed;
+    inset: 0 30% 0 0;
+    max-width: 320px;
+    transform: translateX(-110%);
+    transition: transform 240ms var(--transition-snap);
+    z-index: 9;
+    border-radius: 0 var(--border-radius-lg) var(--border-radius-lg) 0;
+  }
+
+  html.drawer-open .site-sidebar {
+    transform: translateX(0);
+  }
+
+  .content-area {
+    min-height: calc(100vh - 1.5rem - 1.5rem);
   }
 
   .notification-layer {
-    left: 1rem;
-    right: 1rem;
+    right: clamp(0.75rem, 4vw, 1.5rem);
+  }
+}
+
+@media (max-width: 640px) {
+  .nav-toggle {
+    order: -1;
+  }
+
+  .auth-links {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .notification-layer {
+    width: calc(100% - 1.5rem);
+    left: clamp(0.75rem, 4vw, 1.5rem);
+    right: auto;
+  }
+
+  .notification {
+    max-width: 100%;
+  }
+
+  .site-sidebar {
+    inset: 0 15% 0 0;
   }
 }

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -58,265 +58,288 @@
 <% const currentUser = typeof user !== 'undefined' && user ? user : null; %>
 <% const hasBrandLogo = typeof logoUrl !== 'undefined' && logoUrl; %>
 <% const adminCounts = typeof adminActionCounts !== 'undefined' ? adminActionCounts : {}; %>
-<header class="site-header">
-  <div class="brand">
-    <a class="brand-link" href="/">
-      <% if (hasBrandLogo) { %>
-        <img src="<%= logoUrl %>" alt="Logo de <%= typeof wikiName !== 'undefined' ? wikiName : 'Wiki' %>" />
+<div id="overlayHit" class="drawer-overlay" aria-hidden="true"></div>
+<div class="app-shell">
+  <header class="site-header glass-surface">
+    <div class="header-left">
+      <button
+        id="sidebarToggle"
+        class="nav-toggle"
+        type="button"
+        aria-label="Ouvrir le menu"
+        aria-controls="vnav"
+        aria-expanded="false"
+      >
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <div class="brand">
+        <a class="brand-link" href="/">
+          <% if (hasBrandLogo) { %>
+            <img src="<%= logoUrl %>" alt="Logo de <%= typeof wikiName !== 'undefined' ? wikiName : 'Wiki' %>" />
+          <% } %>
+          <span><%= typeof wikiName !== 'undefined' ? wikiName : 'Wiki' %></span>
+        </a>
+      </div>
+    </div>
+    <form method="get" action="/search" class="search-form" role="search">
+      <label class="sr-only" for="wikiSearch">Rechercher</label>
+      <input id="wikiSearch" type="text" name="q" placeholder="Rechercher…" aria-label="Rechercher sur le wiki">
+      <button class="btn" type="submit">Rechercher</button>
+    </form>
+    <div class="auth-links">
+      <% if (currentUser) { %>
+        <% const headerDisplayName = currentUser.display_name || currentUser.username; %>
+        <% const headerColor = currentUser.role_color || null; %>
+        <% const headerClasses = ['user-handle']; %>
+        <% const headerStyle = headerColor && headerColor.hasColor ? headerColor.style : ''; %>
+        <% if (headerColor && headerColor.hasColor) { headerClasses.push('role-colored-text'); headerClasses.push(headerColor.className); } %>
+        <span>Connecté·e : <strong class="<%= headerClasses.join(' ') %>" style="<%= headerStyle %>"><%= headerDisplayName %></strong></span>
+        <form action="/logout" method="post">
+          <button class="btn" type="submit">Déconnexion</button>
+        </form>
+      <% } else { %>
+        <a class="btn" href="/login">Connexion</a>
       <% } %>
-      <span><%= typeof wikiName !== 'undefined' ? wikiName : 'Wiki' %></span>
-    </a>
-  </div>
-  <form method="get" action="/search" class="search-form" role="search">
-    <label class="sr-only" for="wikiSearch">Rechercher</label>
-    <input id="wikiSearch" type="text" name="q" placeholder="Rechercher…" aria-label="Rechercher sur le wiki">
-    <button class="btn" type="submit">Rechercher</button>
-  </form>
-  <div class="auth-links">
-    <% if (currentUser) { %>
-      <% const headerDisplayName = currentUser.display_name || currentUser.username; %>
-      <% const headerColor = currentUser.role_color || null; %>
-      <% const headerClasses = ['user-handle']; %>
-      <% const headerStyle = headerColor && headerColor.hasColor ? headerColor.style : ''; %>
-      <% if (headerColor && headerColor.hasColor) { headerClasses.push('role-colored-text'); headerClasses.push(headerColor.className); } %>
-      <span>Connecté·e : <strong class="<%= headerClasses.join(' ') %>" style="<%= headerStyle %>"><%= headerDisplayName %></strong></span>
-      <form action="/logout" method="post">
-        <button class="btn" type="submit">Déconnexion</button>
-      </form>
-    <% } else { %>
-      <a class="btn" href="/login">Connexion</a>
-    <% } %>
-  </div>
-</header>
+    </div>
+  </header>
 
-<nav class="site-nav" aria-label="Navigation principale">
-  <ul>
-    <li><a href="/">Accueil</a></li>
-    <li><a href="/rss.xml" target="_blank" rel="noopener">Flux RSS</a></li>
-    <% if (typeof hasChangelog !== 'undefined' && hasChangelog) { %>
-      <li><a href="/changelog">Changelog</a></li>
-    <% } %>
-    <% if (typeof canViewIpProfile !== 'undefined' && canViewIpProfile) { %>
-      <li><a href="/profiles/ip/me">Mon profil IP</a></li>
-    <% } %>
-    <% const permissionFlags = permissions && typeof permissions === 'object' ? permissions : {}; %>
-    <% const isAdminUser = !!permissionFlags.is_admin; %>
-    <% const canSubmitContent = !!permissionFlags.can_submit_pages; %>
-    <% const canPublishDirectly = !!(permissionFlags.is_admin || permissionFlags.is_contributor); %>
-    <% const canModerateComments = !!(
-      permissionFlags.can_moderate_comments ||
-      permissionFlags.can_view_comment_queue ||
-      permissionFlags.can_approve_comments ||
-      permissionFlags.can_reject_comments ||
-      permissionFlags.can_delete_comments
-    ); %>
-    <% const canReviewSubmissions = !!(
-      permissionFlags.can_review_submissions ||
-      permissionFlags.can_view_submission_queue ||
-      permissionFlags.can_accept_submissions ||
-      permissionFlags.can_reject_submissions ||
-      permissionFlags.can_comment_on_submissions
-    ); %>
-    <% const canManagePages = !!(
-      permissionFlags.can_manage_pages ||
-      permissionFlags.can_view_page_overview ||
-      permissionFlags.can_edit_pages ||
-      permissionFlags.can_publish_pages ||
-      permissionFlags.can_unpublish_pages ||
-      permissionFlags.can_delete_pages ||
-      permissionFlags.can_restore_pages ||
-      permissionFlags.can_schedule_pages ||
-      permissionFlags.can_manage_page_tags ||
-      permissionFlags.can_view_page_history ||
-      permissionFlags.can_revert_page_history
-    ); %>
-    <% const canViewStats = !!(
-      permissionFlags.can_view_stats ||
-      permissionFlags.can_view_stats_basic ||
-      permissionFlags.can_view_stats_detailed ||
-      permissionFlags.can_export_stats
-    ); %>
-    <% const canManageUsers = !!(
-      permissionFlags.can_manage_users ||
-      permissionFlags.can_view_users ||
-      permissionFlags.can_invite_users ||
-      permissionFlags.can_edit_users ||
-      permissionFlags.can_suspend_users ||
-      permissionFlags.can_delete_users ||
-      permissionFlags.can_reset_passwords ||
-      permissionFlags.can_impersonate_users ||
-      permissionFlags.can_assign_roles
-    ); %>
-    <% const canManageRoles = !!(
-      permissionFlags.can_manage_roles ||
-      permissionFlags.can_view_roles ||
-      permissionFlags.can_create_roles ||
-      permissionFlags.can_edit_roles ||
-      permissionFlags.can_delete_roles ||
-      permissionFlags.can_assign_roles
-    ); %>
-    <% const canManageLikes = !!(
-      permissionFlags.can_manage_likes ||
-      permissionFlags.can_view_likes ||
-      permissionFlags.can_remove_likes
-    ); %>
-    <% const canManageTrash = !!(
-      permissionFlags.can_manage_trash ||
-      permissionFlags.can_view_trash ||
-      permissionFlags.can_restore_trash ||
-      permissionFlags.can_purge_trash
-    ); %>
-    <% const canManageUploads = !!(
-      permissionFlags.can_manage_uploads ||
-      permissionFlags.can_view_uploads ||
-      permissionFlags.can_upload_files ||
-      permissionFlags.can_replace_files ||
-      permissionFlags.can_delete_files
-    ); %>
-    <% const canManageSettings = !!(
-      permissionFlags.can_manage_settings ||
-      permissionFlags.can_update_general_settings ||
-      permissionFlags.can_manage_integrations ||
-      permissionFlags.can_manage_navigation ||
-      permissionFlags.can_manage_features
-    ); %>
-    <% const canManageIpBans = !!(
-      permissionFlags.can_manage_ip_bans ||
-      permissionFlags.can_view_ip_bans ||
-      permissionFlags.can_create_ip_bans ||
-      permissionFlags.can_update_ip_bans ||
-      permissionFlags.can_delete_ip_bans ||
-      permissionFlags.can_lift_ip_bans
-    ); %>
-    <% const canManageIpReputation = !!(
-      permissionFlags.can_manage_ip_reputation ||
-      permissionFlags.can_view_ip_reputation ||
-      permissionFlags.can_tag_ip_reputation ||
-      permissionFlags.can_clear_ip_reputation ||
-      permissionFlags.can_import_ip_reputation
-    ); %>
-    <% const canManageIpProfiles = !!(
-      permissionFlags.can_manage_ip_profiles ||
-      permissionFlags.can_view_ip_profiles ||
-      permissionFlags.can_merge_ip_profiles ||
-      permissionFlags.can_delete_ip_profiles
-    ); %>
-    <% const canReviewBanAppeals = !!(
-      permissionFlags.can_review_ban_appeals ||
-      permissionFlags.can_view_ban_appeals ||
-      permissionFlags.can_accept_ban_appeals ||
-      permissionFlags.can_reject_ban_appeals ||
-      permissionFlags.can_delete_ban_appeals
-    ); %>
-    <% const canViewEvents = !!(
-      permissionFlags.can_view_events ||
-      permissionFlags.can_view_event_log ||
-      permissionFlags.can_export_event_log
-    ); %>
-    <% const canViewSnowflakes = !!(
-      permissionFlags.can_view_snowflakes ||
-      permissionFlags.can_lookup_snowflake_history
-    ); %>
-    <% const hasAdminMenu =
-      isAdminUser ||
-      canModerateComments ||
-      canReviewSubmissions ||
-      canManagePages ||
-      canViewStats ||
-      canManageUsers ||
-      canManageRoles ||
-      canManageLikes ||
-      canManageTrash ||
-      canManageUploads ||
-      canManageSettings ||
-      canManageIpBans ||
-      canManageIpReputation ||
-      canManageIpProfiles ||
-      canReviewBanAppeals ||
-      canViewEvents ||
-      canViewSnowflakes; %>
-    <% if (canSubmitContent && !canPublishDirectly) { %>
-      <li><a href="/new">Contribuer</a></li>
-    <% } else if (canPublishDirectly) { %>
-      <li><a href="/new">Nouvelle page</a></li>
-    <% } %>
-    <li><a href="/account/submissions">Mes contributions</a></li>
-    <% if (hasAdminMenu) { %>
-      <% if (isAdminUser) { %>
-        <li><a href="/new">Nouvelle page</a></li>
-      <% } %>
-      <% if (canReviewSubmissions) { %>
-        <li>
-          <a href="/admin/submissions">
-            Contributions<% if (adminCounts.pendingSubmissions) { %> (<%= adminCounts.pendingSubmissions %>)<% } %>
-          </a>
-        </li>
-      <% } %>
-      <% if (canManagePages) { %>
-        <li><a href="/admin/pages">Articles</a></li>
-      <% } %>
-      <% if (canManageTrash) { %>
-        <li><a href="/admin/trash">Corbeille</a></li>
-      <% } %>
-      <% if (canViewStats) { %>
-        <li><a href="/admin/stats">Statistiques</a></li>
-      <% } %>
-      <% if (canManageUsers) { %>
-        <li><a href="/admin/users">Utilisateurs</a></li>
-      <% } %>
-      <% if (canManageRoles) { %>
-        <li><a href="/admin/roles">Rôles</a></li>
-      <% } %>
-      <% if (canModerateComments) { %>
-        <li>
-          <a href="/admin/comments">
-            Commentaires<% if (adminCounts.pendingComments) { %> (<%= adminCounts.pendingComments %>)<% } %>
-          </a>
-        </li>
-      <% } %>
-      <% if (canManageLikes) { %>
-        <li><a href="/admin/likes">Likes</a></li>
-      <% } %>
-      <% if (canManageIpBans) { %>
-        <li><a href="/admin/ip-bans">Blocages IP</a></li>
-      <% } %>
-      <% if (canManageIpReputation) { %>
-        <li>
-          <a href="/admin/ip-reputation">
-            Surveillance IP<% if (adminCounts.suspiciousIps) { %> (<%= adminCounts.suspiciousIps %>)<% } %>
-          </a>
-        </li>
-      <% } %>
-      <% if (canManageIpProfiles) { %>
-        <li><a href="/admin/ip-profiles">Profils IP</a></li>
-      <% } %>
-      <% if (canReviewBanAppeals) { %>
-        <li>
-          <a href="/admin/ban-appeals">
-            Demandes de déban<% if (adminCounts.pendingBanAppeals) { %> (<%= adminCounts.pendingBanAppeals %>)<% } %>
-          </a>
-        </li>
-      <% } %>
-      <% if (canViewSnowflakes) { %>
-        <li><a href="/admin/snowflakes">Snowflakes</a></li>
-      <% } %>
-      <% if (canViewEvents) { %>
-        <li><a href="/admin/events">Événements</a></li>
-      <% } %>
-      <% if (canManageUploads) { %>
-        <li><a href="/admin/uploads">Images</a></li>
-      <% } %>
-      <% if (canManageSettings) { %>
-        <li><a href="/admin/settings">Paramètres</a></li>
-      <% } %>
-    <% } %>
-  </ul>
-</nav>
+  <div class="shell-body">
+    <aside class="site-sidebar glass-surface" id="siteSidebar">
+      <nav id="vnav" class="site-nav" aria-label="Navigation principale">
+        <ul>
+          <li><a href="/">Accueil</a></li>
+          <li><a href="/rss.xml" target="_blank" rel="noopener">Flux RSS</a></li>
+          <% if (typeof hasChangelog !== 'undefined' && hasChangelog) { %>
+            <li><a href="/changelog">Changelog</a></li>
+          <% } %>
+          <% if (typeof canViewIpProfile !== 'undefined' && canViewIpProfile) { %>
+            <li><a href="/profiles/ip/me">Mon profil IP</a></li>
+          <% } %>
+          <% const permissionFlags = permissions && typeof permissions === 'object' ? permissions : {}; %>
+          <% const isAdminUser = !!permissionFlags.is_admin; %>
+          <% const canSubmitContent = !!permissionFlags.can_submit_pages; %>
+          <% const canPublishDirectly = !!(permissionFlags.is_admin || permissionFlags.is_contributor); %>
+          <% const canModerateComments = !!(
+            permissionFlags.can_moderate_comments ||
+            permissionFlags.can_view_comment_queue ||
+            permissionFlags.can_approve_comments ||
+            permissionFlags.can_reject_comments ||
+            permissionFlags.can_delete_comments
+          ); %>
+          <% const canReviewSubmissions = !!(
+            permissionFlags.can_review_submissions ||
+            permissionFlags.can_view_submission_queue ||
+            permissionFlags.can_accept_submissions ||
+            permissionFlags.can_reject_submissions ||
+            permissionFlags.can_comment_on_submissions
+          ); %>
+          <% const canManagePages = !!(
+            permissionFlags.can_manage_pages ||
+            permissionFlags.can_view_page_overview ||
+            permissionFlags.can_edit_pages ||
+            permissionFlags.can_publish_pages ||
+            permissionFlags.can_unpublish_pages ||
+            permissionFlags.can_delete_pages ||
+            permissionFlags.can_restore_pages ||
+            permissionFlags.can_schedule_pages ||
+            permissionFlags.can_manage_page_tags ||
+            permissionFlags.can_view_page_history ||
+            permissionFlags.can_revert_page_history
+          ); %>
+          <% const canViewStats = !!(
+            permissionFlags.can_view_stats ||
+            permissionFlags.can_view_stats_basic ||
+            permissionFlags.can_view_stats_detailed ||
+            permissionFlags.can_export_stats
+          ); %>
+          <% const canManageUsers = !!(
+            permissionFlags.can_manage_users ||
+            permissionFlags.can_view_users ||
+            permissionFlags.can_invite_users ||
+            permissionFlags.can_edit_users ||
+            permissionFlags.can_suspend_users ||
+            permissionFlags.can_delete_users ||
+            permissionFlags.can_reset_passwords ||
+            permissionFlags.can_impersonate_users ||
+            permissionFlags.can_assign_roles
+          ); %>
+          <% const canManageRoles = !!(
+            permissionFlags.can_manage_roles ||
+            permissionFlags.can_view_roles ||
+            permissionFlags.can_create_roles ||
+            permissionFlags.can_edit_roles ||
+            permissionFlags.can_delete_roles ||
+            permissionFlags.can_assign_roles
+          ); %>
+          <% const canManageLikes = !!(
+            permissionFlags.can_manage_likes ||
+            permissionFlags.can_view_likes ||
+            permissionFlags.can_remove_likes
+          ); %>
+          <% const canManageTrash = !!(
+            permissionFlags.can_manage_trash ||
+            permissionFlags.can_view_trash ||
+            permissionFlags.can_restore_trash ||
+            permissionFlags.can_purge_trash
+          ); %>
+          <% const canManageUploads = !!(
+            permissionFlags.can_manage_uploads ||
+            permissionFlags.can_view_uploads ||
+            permissionFlags.can_upload_files ||
+            permissionFlags.can_replace_files ||
+            permissionFlags.can_delete_files
+          ); %>
+          <% const canManageSettings = !!(
+            permissionFlags.can_manage_settings ||
+            permissionFlags.can_update_general_settings ||
+            permissionFlags.can_manage_integrations ||
+            permissionFlags.can_manage_navigation ||
+            permissionFlags.can_manage_features
+          ); %>
+          <% const canManageIpBans = !!(
+            permissionFlags.can_manage_ip_bans ||
+            permissionFlags.can_view_ip_bans ||
+            permissionFlags.can_create_ip_bans ||
+            permissionFlags.can_update_ip_bans ||
+            permissionFlags.can_delete_ip_bans ||
+            permissionFlags.can_lift_ip_bans
+          ); %>
+          <% const canManageIpReputation = !!(
+            permissionFlags.can_manage_ip_reputation ||
+            permissionFlags.can_view_ip_reputation ||
+            permissionFlags.can_tag_ip_reputation ||
+            permissionFlags.can_clear_ip_reputation ||
+            permissionFlags.can_import_ip_reputation
+          ); %>
+          <% const canManageIpProfiles = !!(
+            permissionFlags.can_manage_ip_profiles ||
+            permissionFlags.can_view_ip_profiles ||
+            permissionFlags.can_merge_ip_profiles ||
+            permissionFlags.can_delete_ip_profiles
+          ); %>
+          <% const canReviewBanAppeals = !!(
+            permissionFlags.can_review_ban_appeals ||
+            permissionFlags.can_view_ban_appeals ||
+            permissionFlags.can_accept_ban_appeals ||
+            permissionFlags.can_reject_ban_appeals ||
+            permissionFlags.can_delete_ban_appeals
+          ); %>
+          <% const canViewEvents = !!(
+            permissionFlags.can_view_events ||
+            permissionFlags.can_view_event_log ||
+            permissionFlags.can_export_event_log
+          ); %>
+          <% const canViewSnowflakes = !!(
+            permissionFlags.can_view_snowflakes ||
+            permissionFlags.can_lookup_snowflake_history
+          ); %>
+          <% const hasAdminMenu =
+            isAdminUser ||
+            canModerateComments ||
+            canReviewSubmissions ||
+            canManagePages ||
+            canViewStats ||
+            canManageUsers ||
+            canManageRoles ||
+            canManageLikes ||
+            canManageTrash ||
+            canManageUploads ||
+            canManageSettings ||
+            canManageIpBans ||
+            canManageIpReputation ||
+            canManageIpProfiles ||
+            canReviewBanAppeals ||
+            canViewEvents ||
+            canViewSnowflakes; %>
+          <% if (canSubmitContent && !canPublishDirectly) { %>
+            <li><a href="/new">Contribuer</a></li>
+          <% } else if (canPublishDirectly) { %>
+            <li><a href="/new">Nouvelle page</a></li>
+          <% } %>
+          <li><a href="/account/submissions">Mes contributions</a></li>
+          <% if (hasAdminMenu) { %>
+            <% if (isAdminUser) { %>
+              <li><a href="/new">Nouvelle page</a></li>
+            <% } %>
+            <% if (canReviewSubmissions) { %>
+              <li>
+                <a href="/admin/submissions">
+                  Contributions<% if (adminCounts.pendingSubmissions) { %> (<%= adminCounts.pendingSubmissions %>)<% } %>
+                </a>
+              </li>
+            <% } %>
+            <% if (canManagePages) { %>
+              <li><a href="/admin/pages">Articles</a></li>
+            <% } %>
+            <% if (canManageTrash) { %>
+              <li><a href="/admin/trash">Corbeille</a></li>
+            <% } %>
+            <% if (canViewStats) { %>
+              <li><a href="/admin/stats">Statistiques</a></li>
+            <% } %>
+            <% if (canManageUsers) { %>
+              <li><a href="/admin/users">Utilisateurs</a></li>
+            <% } %>
+            <% if (canManageRoles) { %>
+              <li><a href="/admin/roles">Rôles</a></li>
+            <% } %>
+            <% if (canModerateComments) { %>
+              <li>
+                <a href="/admin/comments">
+                  Commentaires<% if (adminCounts.pendingComments) { %> (<%= adminCounts.pendingComments %>)<% } %>
+                </a>
+              </li>
+            <% } %>
+            <% if (canManageLikes) { %>
+              <li><a href="/admin/likes">Likes</a></li>
+            <% } %>
+            <% if (canManageIpBans) { %>
+              <li><a href="/admin/ip-bans">Blocages IP</a></li>
+            <% } %>
+            <% if (canManageIpReputation) { %>
+              <li>
+                <a href="/admin/ip-reputation">
+                  Surveillance IP<% if (adminCounts.suspiciousIps) { %> (<%= adminCounts.suspiciousIps %>)<% } %>
+                </a>
+              </li>
+            <% } %>
+            <% if (canManageIpProfiles) { %>
+              <li><a href="/admin/ip-profiles">Profils IP</a></li>
+            <% } %>
+            <% if (canReviewBanAppeals) { %>
+              <li>
+                <a href="/admin/ban-appeals">
+                  Demandes de déban<% if (adminCounts.pendingBanAppeals) { %> (<%= adminCounts.pendingBanAppeals %>)<% } %>
+                </a>
+              </li>
+            <% } %>
+            <% if (canViewSnowflakes) { %>
+              <li><a href="/admin/snowflakes">Snowflakes</a></li>
+            <% } %>
+            <% if (canViewEvents) { %>
+              <li><a href="/admin/events">Événements</a></li>
+            <% } %>
+            <% if (canManageUploads) { %>
+              <li><a href="/admin/uploads">Images</a></li>
+            <% } %>
+            <% if (canManageSettings) { %>
+              <li><a href="/admin/settings">Paramètres</a></li>
+            <% } %>
+          <% } %>
+        </ul>
+      </nav>
+    </aside>
 
-<% const initialNotifications = typeof notifications !== 'undefined' ? notifications : []; %>
-<div class="notification-layer" id="notificationLayer"></div>
-<main class="page-content"><%- body %></main>
-<footer class="site-footer"><small><%- typeof footerText !== 'undefined' ? footerText : '' %></small></footer>
+    <% const initialNotifications = typeof notifications !== 'undefined' ? notifications : []; %>
+    <div class="content-area">
+      <div class="notification-layer" id="notificationLayer"></div>
+      <main class="page-content"><%- body %></main>
+      <footer class="site-footer glass-surface"><small><%- typeof footerText !== 'undefined' ? footerText : '' %></small></footer>
+    </div>
+  </div>
+</div>
 
 <script type="application/json" id="initial-notifications"><%- JSON.stringify(initialNotifications).replace(/</g, '\\u003c') %></script>
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>


### PR DESCRIPTION
## Summary
- rebuild the main layout with a glassmorphism header, burger toggle, sidebar drawer, and overlay for responsive navigation
- restyle the public stylesheet to deliver an Apple-inspired liquid glass and Bluecord aesthetic with animated hover and click interactions
- adjust notifications and content areas to fit the new responsive material-inspired shell

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68ddb5cd3ff48321adae22613d0c04b9