### PR TITLE
Improve readability of role permissions in admin UI

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1781,12 +1781,13 @@ kbd {
   display: flex;
   align-items: flex-start;
   gap: 0.55rem;
-  padding: 0.65rem 0.75rem;
+  padding: 0.75rem 0.85rem;
   border-radius: var(--radius-sm);
-  background: rgba(10, 18, 36, 0.75);
-  border: 1px solid rgba(134, 182, 255, 0.12);
+  background: rgba(18, 32, 64, 0.9);
+  border: 1px solid rgba(134, 182, 255, 0.2);
   transition: var(--transition-base);
   cursor: pointer;
+  color: var(--text-primary);
 }
 
 .role-permission:hover,
@@ -1800,8 +1801,8 @@ kbd {
 }
 
 .role-permission.is-aggregate {
-  background: rgba(33, 68, 138, 0.55);
-  border-color: rgba(108, 140, 255, 0.35);
+  background: rgba(42, 78, 160, 0.65);
+  border-color: rgba(108, 140, 255, 0.4);
 }
 
 .permission-title {
@@ -1814,9 +1815,10 @@ kbd {
 
 .permission-description {
   display: block;
-  margin-top: 0.25rem;
-  font-size: 0.9rem;
-  color: var(--text-muted);
+  margin-top: 0.35rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: rgba(226, 235, 255, 0.82);
 }
 
 .badge-aggregate {


### PR DESCRIPTION
## Summary
- increase contrast and spacing for role permission tiles to make labels more legible
- enlarge permission description text for improved readability in the admin roles view

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ddc20944dc8321be9aab84fa3c49b6