### PR TITLE
Improve cross-browser rendering of role colors

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1155,6 +1155,8 @@ textarea {
 .role-colored-text {
   position: relative;
   color: var(--role-fallback-color, var(--role-color-1, inherit));
+  background-repeat: no-repeat;
+  background-image: none;
 }
 
 .role-colored-text.role-color--gradient,
@@ -1171,6 +1173,27 @@ textarea {
     color: transparent;
     -webkit-background-clip: text;
     background-clip: text;
+  }
+}
+
+@supports (-moz-background-clip: text) {
+  .role-colored-text.role-color--gradient,
+  .role-colored-text.role-color--rainbow {
+    color: transparent;
+    background-clip: text;
+    -moz-background-clip: text;
+  }
+}
+
+.role-colored-text.role-color--gradient,
+.role-colored-text.role-color--rainbow {
+  -webkit-text-fill-color: currentColor;
+}
+
+@supports (-webkit-text-fill-color: transparent) {
+  .role-colored-text.role-color--gradient,
+  .role-colored-text.role-color--rainbow {
+    -webkit-text-fill-color: transparent;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure role colored text always defines a background so role gradients display everywhere
- add vendor-prefixed background clip and text fill rules so gradients render correctly in more browsers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de2d2c5a30832192e5601017b8bb29