### PR TITLE
Fix mobile drawer overlay covering sidebar

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4,9 +4,32 @@ let quillCodeBlockRegistered = false;
 (function () {
   const toggleBtn = document.getElementById("sidebarToggle");
   const overlayHit = document.getElementById("overlayHit"); // zone cliquable à droite
+  const drawer = document.querySelector(".nav-drawer");
   const links = document.querySelectorAll("#vnav a");
   const closeButtons = document.querySelectorAll("[data-close-nav]");
   const html = document.documentElement;
+
+  const clearOverlayBounds = () => {
+    if (!overlayHit) return;
+    overlayHit.style.removeProperty("--overlay-left");
+  };
+
+  const scheduleOverlaySync = () => {
+    if (!overlayHit || !drawer) {
+      return;
+    }
+    if (!html.classList.contains("drawer-open")) {
+      clearOverlayBounds();
+      return;
+    }
+    const styles = window.getComputedStyle(drawer);
+    const leftValue = parseFloat(styles.left) || 0;
+    const overlayLeft = Math.min(
+      window.innerWidth,
+      Math.max(0, leftValue + drawer.offsetWidth),
+    );
+    overlayHit.style.setProperty("--overlay-left", `${overlayLeft}px`);
+  };
 
   const setExpanded = (expanded) => {
     if (!toggleBtn) return;
@@ -20,6 +43,7 @@ let quillCodeBlockRegistered = false;
   const openDrawer = () => {
     html.classList.add("drawer-open");
     setExpanded(true);
+    scheduleOverlaySync();
   };
   const closeDrawer = () => {
     if (!html.classList.contains("drawer-open")) {
@@ -27,6 +51,7 @@ let quillCodeBlockRegistered = false;
     }
     html.classList.remove("drawer-open");
     setExpanded(false);
+    clearOverlayBounds();
   };
 
   if (toggleBtn) {
@@ -40,6 +65,10 @@ let quillCodeBlockRegistered = false;
   overlayHit && overlayHit.addEventListener("click", closeDrawer);
   closeButtons.forEach((btn) => btn.addEventListener("click", closeDrawer));
   links.forEach((a) => a.addEventListener("click", closeDrawer));
+
+  scheduleOverlaySync();
+
+  window.addEventListener("resize", scheduleOverlaySync, { passive: true });
 
   document.addEventListener("keydown", (event) => {
     if (event.key === "Escape") {

--- a/public/style.css
+++ b/public/style.css
@@ -541,7 +541,10 @@ html.drawer-open .nav-drawer {
 
 .drawer-overlay {
   position: fixed;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: var(--overlay-left, 0);
   z-index: 2;
   background: rgba(3, 11, 29, 0.55);
   backdrop-filter: blur(16px);


### PR DESCRIPTION
## Summary
- keep the drawer overlay anchored to the content area instead of covering the sidebar
- compute the overlay bounds when the drawer opens and on resize so the menu stays interactive on mobile

## Testing
- manual: npm start

------
https://chatgpt.com/codex/tasks/task_e_68de3c7d8ca083219d7dfb4b5f051216