### PR TITLE
Adjust mobile navigation spacing

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -559,6 +559,24 @@ html.drawer-open .drawer-overlay {
   pointer-events: auto;
 }
 
+@media (max-width: 600px) {
+  .nav-content {
+    gap: 0.25rem;
+  }
+
+  .nav-section {
+    gap: 0.18rem;
+  }
+
+  .nav-list {
+    gap: 0.1rem;
+  }
+
+  .nav-list a {
+    padding: 0.38rem 0.8rem;
+  }
+}
+
 .sr-only {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
## Summary
- tighten navigation spacing for the drawer on small screens by reducing section gaps
- decrease vertical padding on mobile navigation links to shorten button height

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de47907a788321ab7cd9e9712a7fd7