### PR TITLE
Reduce navigation button spacing

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -473,7 +473,7 @@ html.drawer-open .nav-drawer {
 
 .nav-section {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.45rem;
 }
 
 .nav-section-title {
@@ -489,14 +489,14 @@ html.drawer-open .nav-drawer {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.35rem;
+  gap: 0.18rem;
 }
 
 .nav-list a {
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  padding: 0.55rem 0.8rem;
+  padding: 0.42rem 0.8rem;
   border-radius: var(--radius-small);
   background: transparent;
   color: var(--color-text-muted);
@@ -573,7 +573,7 @@ html.drawer-open .drawer-overlay {
   }
 
   .nav-list a {
-    padding: 0.38rem 0.8rem;
+    padding: 0.34rem 0.8rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- shrink vertical gaps between navigation sections and entries
- tighten drawer button padding for a more compact menu layout

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68de49ecaf708321b5c38f8b6149744d