### PR TITLE
Enhance navigation UI and role color displays

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -38,6 +38,10 @@ let quillCodeBlockRegistered = false;
       "aria-label",
       expanded ? "Fermer le menu" : "Ouvrir le menu",
     );
+    const icon = toggleBtn.querySelector(".icon");
+    if (icon) {
+      icon.textContent = expanded ? "✕" : "☰";
+    }
   };
 
   const openDrawer = () => {

--- a/public/style.css
+++ b/public/style.css
@@ -341,6 +341,33 @@ pre {
   font-weight: 600;
 }
 
+.role-colored-text {
+  background-image: var(--role-gradient, none);
+  background-size: var(--role-background-size, 100% 100%);
+  background-position: var(--role-background-position, 0% 50%);
+  background-repeat: no-repeat;
+  animation: var(--role-animation, none);
+  color: var(--role-fallback-color, currentColor);
+  -webkit-text-fill-color: var(--role-fallback-color, currentColor);
+  background-clip: text;
+  -webkit-background-clip: text;
+}
+
+.role-colored-text.role-color--gradient,
+.role-colored-text.role-color--rainbow {
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
+
+@keyframes role-rainbow {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 100% 50%;
+  }
+}
+
 .btn {
   appearance: none;
   border: none;
@@ -437,6 +464,13 @@ html.drawer-open .nav-drawer {
   margin-bottom: 1.25rem;
 }
 
+.nav-close {
+  margin-left: auto;
+  width: 40px;
+  height: 40px;
+  display: none;
+}
+
 .nav-drawer-icon {
   display: none;
   width: 40px;
@@ -467,6 +501,10 @@ html.drawer-open .nav-drawer {
 
 @media (max-width: 1024px) {
   .nav-drawer-icon {
+    display: inline-flex;
+  }
+
+  .nav-close {
     display: inline-flex;
   }
 }
@@ -503,11 +541,34 @@ html.drawer-open .nav-drawer {
   transition: background var(--transition-base), color var(--transition-base), transform var(--transition-base);
 }
 
+.nav-item-icon {
+  width: 1.9rem;
+  height: 1.9rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-small);
+  background: rgba(92, 139, 255, 0.08);
+  color: var(--color-text-muted);
+  font-size: 1rem;
+  transition: background var(--transition-base), color var(--transition-base), transform var(--transition-base);
+}
+
+.nav-item-label {
+  flex: 1;
+}
+
 .nav-list a:hover,
 .nav-list a:focus {
   background: rgba(92, 139, 255, 0.18);
   color: var(--color-text);
   transform: translateX(4px);
+}
+
+.nav-list a:hover .nav-item-icon,
+.nav-list a:focus .nav-item-icon {
+  background: rgba(92, 139, 255, 0.28);
+  color: var(--color-text);
 }
 
 .page-content {
@@ -928,6 +989,10 @@ input[type="radio"] {
   }
 
   .drawer-overlay {
+    display: none;
+  }
+
+  .nav-close {
     display: none;
   }
 }

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -70,6 +70,10 @@ import {
 } from "../utils/settingsService.js";
 import { pushNotification } from "../utils/notifications.js";
 import {
+  resolveHandleColors,
+  getHandleColor,
+} from "../utils/userHandles.js";
+import {
   listRoles,
   listRolesWithUsage,
   getRoleById,
@@ -1990,6 +1994,19 @@ r.get(
   const newLikesCount = Number(newLikesRow?.total || 0);
   const newViewsCount = Number(newViewsRow?.total || 0);
 
+  const statsHandleMap = await resolveHandleColors([
+    ...recentEvents.map((event) => event.username),
+    ...topCommenters.map((row) => row.author),
+  ]);
+  const decoratedRecentEvents = recentEvents.map((event) => ({
+    ...event,
+    userRole: getHandleColor(event.username, statsHandleMap),
+  }));
+  const decoratedTopCommenters = topCommenters.map((row) => ({
+    ...row,
+    authorRole: getHandleColor(row.author, statsHandleMap),
+  }));
+
   const engagementHighlights = [
     {
       icon: "📄",
@@ -2063,7 +2080,7 @@ r.get(
     engagementHighlights,
     topLikedPages,
     topLikedPagination,
-    topCommenters,
+    topCommenters: decoratedTopCommenters,
     topCommentersPagination,
     topCommentedPages,
     topCommentedPagination,
@@ -2076,7 +2093,7 @@ r.get(
     ipViewsByPage,
     ipViewsPagination,
     recentPages,
-    recentEvents,
+    recentEvents: decoratedRecentEvents,
     viewTrends,
     liveVisitors,
     liveVisitorsPagination,
@@ -3422,10 +3439,17 @@ r.get(
       LIMIT ? OFFSET ?`,
     [...params, basePagination.perPage, offset],
   );
+  const eventHandleMap = await resolveHandleColors(
+    events.map((event) => event.username),
+  );
+  const decoratedEvents = events.map((event) => ({
+    ...event,
+    userRole: getHandleColor(event.username, eventHandleMap),
+  }));
   const pagination = decoratePagination(req, basePagination);
 
   res.render("admin/events", {
-    events,
+    events: decoratedEvents,
     pagination,
     searchTerm,
   });

--- a/utils/userHandles.js
+++ b/utils/userHandles.js
@@ -1,0 +1,67 @@
+import { all } from "../db.js";
+import {
+  parseStoredRoleColor,
+  buildRoleColorPresentation,
+} from "./roleColors.js";
+
+function normalizeHandles(handles = []) {
+  const normalized = new Set();
+  for (const value of handles) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      continue;
+    }
+    normalized.add(trimmed.toLowerCase());
+  }
+  return Array.from(normalized);
+}
+
+export async function resolveHandleColors(handles = []) {
+  const normalized = normalizeHandles(handles);
+  if (!normalized.length) {
+    return {};
+  }
+  const placeholders = normalized.map(() => "?").join(", ");
+  const rows = await all(
+    `SELECT u.username,
+            u.display_name,
+            r.color AS role_color
+       FROM users u
+       LEFT JOIN roles r ON r.id = u.role_id
+      WHERE LOWER(u.username) IN (${placeholders})
+         OR (u.display_name IS NOT NULL AND LOWER(u.display_name) IN (${placeholders}))`,
+    [...normalized, ...normalized],
+  );
+  const mapping = {};
+  for (const row of rows) {
+    const scheme = parseStoredRoleColor(row.role_color);
+    const color = buildRoleColorPresentation(scheme);
+    const payload = {
+      username: row.username || null,
+      displayName: row.display_name || null,
+      color,
+      colorScheme: scheme,
+    };
+    if (row.username) {
+      mapping[row.username.toLowerCase()] = payload;
+    }
+    if (row.display_name) {
+      mapping[row.display_name.toLowerCase()] = payload;
+    }
+  }
+  return mapping;
+}
+
+export function getHandleColor(handle, mapping = {}) {
+  if (typeof handle !== "string") {
+    return null;
+  }
+  const normalized = handle.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  return mapping[normalized] || null;
+}

--- a/views/admin/events.ejs
+++ b/views/admin/events.ejs
@@ -45,7 +45,17 @@
               <td><code><%= ev.snowflake_id || ev.id %></code></td>
               <td><strong><%= ev.type %></strong></td>
               <td><code><%= ev.channel %></code></td>
-              <td><%= ev.username || '-' %></td>
+              <% const eventUserColor = ev.userRole && ev.userRole.color ? ev.userRole.color : null; %>
+              <% const eventUserClasses = ['user-handle', 'event-user']; %>
+              <% const eventUserStyle = eventUserColor && eventUserColor.hasColor ? eventUserColor.style : ''; %>
+              <% if (eventUserColor && eventUserColor.hasColor) { eventUserClasses.push('role-colored-text'); eventUserClasses.push(eventUserColor.className); } %>
+              <td>
+                <% if (ev.username) { %>
+                  <strong class="<%= eventUserClasses.join(' ') %>" style="<%= eventUserStyle %>"><%= ev.username %></strong>
+                <% } else { %>
+                  -
+                <% } %>
+              </td>
               <td><%= ev.ip || '-' %></td>
               <td><%= new Date(ev.created_at).toLocaleString('fr-FR') %></td>
             </tr>

--- a/views/admin/stats.ejs
+++ b/views/admin/stats.ejs
@@ -281,7 +281,13 @@
             </div>
             <div class="text-muted text-sm">
               <time datetime="<%= event.created_at %>"><%= new Date(event.created_at).toLocaleString('fr-FR') %></time>
-              <% if (event.username) { %> · <span>par <strong><%= event.username %></strong></span><% } %>
+              <% if (event.username) { %>
+                <% const eventUserColor = event.userRole && event.userRole.color ? event.userRole.color : null; %>
+                <% const eventUserClasses = ['user-handle', 'event-user']; %>
+                <% const eventUserStyle = eventUserColor && eventUserColor.hasColor ? eventUserColor.style : ''; %>
+                <% if (eventUserColor && eventUserColor.hasColor) { eventUserClasses.push('role-colored-text'); eventUserClasses.push(eventUserColor.className); } %>
+                · <span>par <strong class="<%= eventUserClasses.join(' ') %>" style="<%= eventUserStyle %>"><%= event.username %></strong></span>
+              <% } %>
             </div>
           </li>
         <% }) %>
@@ -334,8 +340,18 @@
           </thead>
           <tbody>
             <% topCommenters.forEach(row => { %>
+              <% const commenterColor = row.authorRole && row.authorRole.color ? row.authorRole.color : null; %>
+              <% const commenterClasses = ['user-handle', 'commenter-name']; %>
+              <% const commenterStyle = commenterColor && commenterColor.hasColor ? commenterColor.style : ''; %>
+              <% if (commenterColor && commenterColor.hasColor) { commenterClasses.push('role-colored-text'); commenterClasses.push(commenterColor.className); } %>
               <tr>
-                <td><%= row.author %></td>
+                <td>
+                  <% if (row.author && row.author !== 'Anonyme') { %>
+                    <strong class="<%= commenterClasses.join(' ') %>" style="<%= commenterStyle %>"><%= row.author %></strong>
+                  <% } else { %>
+                    <%= row.author %>
+                  <% } %>
+                </td>
                 <td><%= row.comments %></td>
               </tr>
             <% }) %>

--- a/views/admin/submission_detail.ejs
+++ b/views/admin/submission_detail.ejs
@@ -18,7 +18,21 @@
     </div>
     <div>
       <strong>Auteur proposé</strong>
-      <p><%= submission.author_name || submission.submitted_by || '–' %></p>
+      <% const submissionAuthorHandle = submission.author_name || submission.submitted_by; %>
+      <% const submissionAuthorRole = submission.author_name ? submission.authorNameRole : submission.submittedByRole; %>
+      <% if (submissionAuthorHandle) { %>
+        <% const submissionAuthorColor = submissionAuthorRole && submissionAuthorRole.color ? submissionAuthorRole.color : null; %>
+        <% const submissionAuthorClasses = ['user-handle', 'submission-author']; %>
+        <% const submissionAuthorStyle = submissionAuthorColor && submissionAuthorColor.hasColor ? submissionAuthorColor.style : ''; %>
+        <% if (submissionAuthorColor && submissionAuthorColor.hasColor) { submissionAuthorClasses.push('role-colored-text'); submissionAuthorClasses.push(submissionAuthorColor.className); } %>
+        <p>
+          <strong class="<%= submissionAuthorClasses.join(' ') %>" style="<%= submissionAuthorStyle %>">
+            <%= submissionAuthorHandle %>
+          </strong>
+        </p>
+      <% } else { %>
+        <p>–</p>
+      <% } %>
     </div>
     <div>
       <strong>Proposé le</strong>
@@ -42,7 +56,11 @@
         <p>
           <%= new Date(submission.reviewed_at).toLocaleString('fr-FR') %>
           <% if (submission.reviewer_username) { %>
-            · par <strong><%= submission.reviewer_username %></strong>
+            <% const reviewerColor = submission.reviewerRole && submission.reviewerRole.color ? submission.reviewerRole.color : null; %>
+            <% const reviewerClasses = ['user-handle', 'submission-reviewer']; %>
+            <% const reviewerStyle = reviewerColor && reviewerColor.hasColor ? reviewerColor.style : ''; %>
+            <% if (reviewerColor && reviewerColor.hasColor) { reviewerClasses.push('role-colored-text'); reviewerClasses.push(reviewerColor.className); } %>
+            · par <strong class="<%= reviewerClasses.join(' ') %>" style="<%= reviewerStyle %>"><%= submission.reviewer_username %></strong>
           <% } %>
         </p>
       </div>

--- a/views/admin/submissions.ejs
+++ b/views/admin/submissions.ejs
@@ -50,7 +50,21 @@
               <td><code><%= item.snowflake_id %></code></td>
               <td><%= item.type === 'edit' ? 'Modification' : 'Création' %></td>
               <td><strong><%= item.title %></strong></td>
-              <td><%= item.author_name || item.submitted_by || '–' %></td>
+              <% const pendingAuthorHandle = item.author_name || item.submitted_by; %>
+              <% const pendingAuthorRole = item.author_name ? item.authorNameRole : item.submittedByRole; %>
+              <td>
+                <% if (pendingAuthorHandle) { %>
+                  <% const pendingAuthorColor = pendingAuthorRole && pendingAuthorRole.color ? pendingAuthorRole.color : null; %>
+                  <% const pendingAuthorClasses = ['user-handle', 'submission-author']; %>
+                  <% const pendingAuthorStyle = pendingAuthorColor && pendingAuthorColor.hasColor ? pendingAuthorColor.style : ''; %>
+                  <% if (pendingAuthorColor && pendingAuthorColor.hasColor) { pendingAuthorClasses.push('role-colored-text'); pendingAuthorClasses.push(pendingAuthorColor.className); } %>
+                  <strong class="<%= pendingAuthorClasses.join(' ') %>" style="<%= pendingAuthorStyle %>">
+                    <%= pendingAuthorHandle %>
+                  </strong>
+                <% } else { %>
+                  –
+                <% } %>
+              </td>
               <td>
                 <% if (item.current_slug) { %>
                   <a href="/wiki/<%= item.current_slug %>"><code><%= item.current_slug %></code></a>
@@ -115,9 +129,35 @@
                   <div><a href="/wiki/<%= item.result_slug_id %>"><code><%= item.result_slug_id %></code></a></div>
                 <% } %>
               </td>
-              <td><%= item.author_name || item.submitted_by || '–' %></td>
+              <% const recentAuthorHandle = item.author_name || item.submitted_by; %>
+              <% const recentAuthorRole = item.author_name ? item.authorNameRole : item.submittedByRole; %>
+              <td>
+                <% if (recentAuthorHandle) { %>
+                  <% const recentAuthorColor = recentAuthorRole && recentAuthorRole.color ? recentAuthorRole.color : null; %>
+                  <% const recentAuthorClasses = ['user-handle', 'submission-author']; %>
+                  <% const recentAuthorStyle = recentAuthorColor && recentAuthorColor.hasColor ? recentAuthorColor.style : ''; %>
+                  <% if (recentAuthorColor && recentAuthorColor.hasColor) { recentAuthorClasses.push('role-colored-text'); recentAuthorClasses.push(recentAuthorColor.className); } %>
+                  <strong class="<%= recentAuthorClasses.join(' ') %>" style="<%= recentAuthorStyle %>">
+                    <%= recentAuthorHandle %>
+                  </strong>
+                <% } else { %>
+                  –
+                <% } %>
+              </td>
               <td class="status <%= item.status %>"><%= item.status === 'approved' ? 'Approuvée' : 'Rejetée' %></td>
-              <td><%= item.reviewer_username || '–' %></td>
+              <% const reviewerColor = item.reviewerRole && item.reviewerRole.color ? item.reviewerRole.color : null; %>
+              <% const reviewerClasses = ['user-handle', 'submission-reviewer']; %>
+              <% const reviewerStyle = reviewerColor && reviewerColor.hasColor ? reviewerColor.style : ''; %>
+              <% if (reviewerColor && reviewerColor.hasColor) { reviewerClasses.push('role-colored-text'); reviewerClasses.push(reviewerColor.className); } %>
+              <td>
+                <% if (item.reviewer_username) { %>
+                  <strong class="<%= reviewerClasses.join(' ') %>" style="<%= reviewerStyle %>">
+                    <%= item.reviewer_username %>
+                  </strong>
+                <% } else { %>
+                  –
+                <% } %>
+              </td>
               <td>
                 <% if (item.reviewed_at) { %>
                   <%= new Date(item.reviewed_at).toLocaleString('fr-FR') %>

--- a/views/history.ejs
+++ b/views/history.ejs
@@ -21,10 +21,18 @@
       </thead>
       <tbody>
         <% revisions.forEach((rev) => { %>
+          <% const revAuthorColor = rev.authorRole && rev.authorRole.color ? rev.authorRole.color : null; %>
+          <% const revAuthorClasses = ['user-handle', 'history-author']; %>
+          <% const revAuthorStyle = revAuthorColor && revAuthorColor.hasColor ? revAuthorColor.style : ''; %>
+          <% if (revAuthorColor && revAuthorColor.hasColor) { revAuthorClasses.push('role-colored-text'); revAuthorClasses.push(revAuthorColor.className); } %>
           <tr>
             <td><%= rev.revision %></td>
             <td><%= rev.title %></td>
-            <td><%= rev.author || 'Inconnu' %></td>
+            <td>
+              <strong class="<%= revAuthorClasses.join(' ') %>" style="<%= revAuthorStyle %>">
+                <%= rev.author || 'Inconnu' %>
+              </strong>
+            </td>
             <td><%= rev.created_at %></td>
             <td><a class="btn" data-icon="📝" href="/wiki/<%= page.slug_id %>/revisions/<%= rev.revision %>">Consulter</a></td>
           </tr>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -118,29 +118,67 @@
       <div class="nav-drawer-header">
         <span class="nav-drawer-icon" aria-hidden="true">☰</span>
         <span class="nav-title">Explorer</span>
+        <button class="nav-close icon-button" type="button" data-close-nav aria-label="Fermer la navigation">
+          <span class="icon" aria-hidden="true">✕</span>
+        </button>
       </div>
       <div class="nav-content">
         <section class="nav-section">
           <h2 class="nav-section-title">Général</h2>
           <ul class="nav-list">
-            <li><a href="/">Accueil</a></li>
-            <li><a href="/rss.xml" target="_blank" rel="noopener">Flux RSS</a></li>
+            <li>
+              <a href="/">
+                <span class="nav-item-icon" aria-hidden="true">🏠</span>
+                <span class="nav-item-label">Accueil</span>
+              </a>
+            </li>
+            <li>
+              <a href="/rss.xml" target="_blank" rel="noopener">
+                <span class="nav-item-icon" aria-hidden="true">📡</span>
+                <span class="nav-item-label">Flux RSS</span>
+              </a>
+            </li>
             <% if (typeof hasChangelog !== 'undefined' && hasChangelog) { %>
-              <li><a href="/changelog">Changelog</a></li>
+              <li>
+                <a href="/changelog">
+                  <span class="nav-item-icon" aria-hidden="true">📝</span>
+                  <span class="nav-item-label">Changelog</span>
+                </a>
+              </li>
             <% } %>
             <% if (typeof canViewIpProfile !== 'undefined' && canViewIpProfile) { %>
-              <li><a href="/profiles/ip/me">Mon profil IP</a></li>
+              <li>
+                <a href="/profiles/ip/me">
+                  <span class="nav-item-icon" aria-hidden="true">🛡️</span>
+                  <span class="nav-item-label">Mon profil IP</span>
+                </a>
+              </li>
             <% } %>
             <% const permissionFlags = permissions && typeof permissions === 'object' ? permissions : {}; %>
             <% const isAdminUser = !!permissionFlags.is_admin; %>
             <% const canSubmitContent = !!permissionFlags.can_submit_pages; %>
             <% const canPublishDirectly = !!(permissionFlags.is_admin || permissionFlags.is_contributor); %>
             <% if (canSubmitContent && !canPublishDirectly) { %>
-              <li><a href="/new">Contribuer</a></li>
+              <li>
+                <a href="/new">
+                  <span class="nav-item-icon" aria-hidden="true">✍️</span>
+                  <span class="nav-item-label">Contribuer</span>
+                </a>
+              </li>
             <% } else if (canPublishDirectly) { %>
-              <li><a href="/new">Nouvelle page</a></li>
+              <li>
+                <a href="/new">
+                  <span class="nav-item-icon" aria-hidden="true">➕</span>
+                  <span class="nav-item-label">Nouvelle page</span>
+                </a>
+              </li>
             <% } %>
-            <li><a href="/account/submissions">Mes contributions</a></li>
+            <li>
+              <a href="/account/submissions">
+                <span class="nav-item-icon" aria-hidden="true">📚</span>
+                <span class="nav-item-label">Mes contributions</span>
+              </a>
+            </li>
           </ul>
         </section>
         <% const canModerateComments = !!(
@@ -280,71 +318,148 @@
             <h2 class="nav-section-title">Administration</h2>
             <ul class="nav-list">
               <% if (isAdminUser) { %>
-                <li><a href="/new">Nouvelle page</a></li>
+                <li>
+                  <a href="/new">
+                    <span class="nav-item-icon" aria-hidden="true">🆕</span>
+                    <span class="nav-item-label">Nouvelle page</span>
+                  </a>
+                </li>
               <% } %>
               <% if (canReviewSubmissions) { %>
                 <li>
                   <a href="/admin/submissions">
-                    Contributions<% if (adminCounts.pendingSubmissions) { %> (<%= adminCounts.pendingSubmissions %>)<% } %>
+                    <span class="nav-item-icon" aria-hidden="true">🗳️</span>
+                    <span class="nav-item-label">
+                      Contributions<% if (adminCounts.pendingSubmissions) { %> (<%= adminCounts.pendingSubmissions %>)<% } %>
+                    </span>
                   </a>
                 </li>
               <% } %>
               <% if (canManagePages) { %>
-                <li><a href="/admin/pages">Articles</a></li>
+                <li>
+                  <a href="/admin/pages">
+                    <span class="nav-item-icon" aria-hidden="true">📄</span>
+                    <span class="nav-item-label">Articles</span>
+                  </a>
+                </li>
               <% } %>
               <% if (canManageTrash) { %>
-                <li><a href="/admin/trash">Corbeille</a></li>
+                <li>
+                  <a href="/admin/trash">
+                    <span class="nav-item-icon" aria-hidden="true">🗑️</span>
+                    <span class="nav-item-label">Corbeille</span>
+                  </a>
+                </li>
               <% } %>
               <% if (canViewStats) { %>
-                <li><a href="/admin/stats">Statistiques</a></li>
+                <li>
+                  <a href="/admin/stats">
+                    <span class="nav-item-icon" aria-hidden="true">📊</span>
+                    <span class="nav-item-label">Statistiques</span>
+                  </a>
+                </li>
               <% } %>
               <% if (canManageUsers) { %>
-                <li><a href="/admin/users">Utilisateurs</a></li>
+                <li>
+                  <a href="/admin/users">
+                    <span class="nav-item-icon" aria-hidden="true">👥</span>
+                    <span class="nav-item-label">Utilisateurs</span>
+                  </a>
+                </li>
               <% } %>
               <% if (canManageRoles) { %>
-                <li><a href="/admin/roles">Rôles</a></li>
+                <li>
+                  <a href="/admin/roles">
+                    <span class="nav-item-icon" aria-hidden="true">🛡️</span>
+                    <span class="nav-item-label">Rôles</span>
+                  </a>
+                </li>
               <% } %>
               <% if (canModerateComments) { %>
                 <li>
                   <a href="/admin/comments">
-                    Commentaires<% if (adminCounts.pendingComments) { %> (<%= adminCounts.pendingComments %>)<% } %>
+                    <span class="nav-item-icon" aria-hidden="true">💬</span>
+                    <span class="nav-item-label">
+                      Commentaires<% if (adminCounts.pendingComments) { %> (<%= adminCounts.pendingComments %>)<% } %>
+                    </span>
                   </a>
                 </li>
               <% } %>
               <% if (canManageLikes) { %>
-                <li><a href="/admin/likes">Likes</a></li>
+                <li>
+                  <a href="/admin/likes">
+                    <span class="nav-item-icon" aria-hidden="true">💖</span>
+                    <span class="nav-item-label">Likes</span>
+                  </a>
+                </li>
               <% } %>
               <% if (canManageIpBans) { %>
-                <li><a href="/admin/ip-bans">Blocages IP</a></li>
+                <li>
+                  <a href="/admin/ip-bans">
+                    <span class="nav-item-icon" aria-hidden="true">🚫</span>
+                    <span class="nav-item-label">Blocages IP</span>
+                  </a>
+                </li>
               <% } %>
               <% if (canManageIpReputation) { %>
                 <li>
                   <a href="/admin/ip-reputation">
-                    Surveillance IP<% if (adminCounts.suspiciousIps) { %> (<%= adminCounts.suspiciousIps %>)<% } %>
+                    <span class="nav-item-icon" aria-hidden="true">🕵️</span>
+                    <span class="nav-item-label">
+                      Surveillance IP<% if (adminCounts.suspiciousIps) { %> (<%= adminCounts.suspiciousIps %>)<% } %>
+                    </span>
                   </a>
                 </li>
               <% } %>
               <% if (canManageIpProfiles) { %>
-                <li><a href="/admin/ip-profiles">Profils IP</a></li>
+                <li>
+                  <a href="/admin/ip-profiles">
+                    <span class="nav-item-icon" aria-hidden="true">🔍</span>
+                    <span class="nav-item-label">Profils IP</span>
+                  </a>
+                </li>
               <% } %>
               <% if (canReviewBanAppeals) { %>
                 <li>
                   <a href="/admin/ban-appeals">
-                    Demandes de déban<% if (adminCounts.pendingBanAppeals) { %> (<%= adminCounts.pendingBanAppeals %>)<% } %>
+                    <span class="nav-item-icon" aria-hidden="true">🙏</span>
+                    <span class="nav-item-label">
+                      Demandes de déban<% if (adminCounts.pendingBanAppeals) { %> (<%= adminCounts.pendingBanAppeals %>)<% } %>
+                    </span>
                   </a>
                 </li>
               <% } %>
               <% if (canViewSnowflakes) { %>
-                <li><a href="/admin/snowflakes">Snowflakes</a></li>
+                <li>
+                  <a href="/admin/snowflakes">
+                    <span class="nav-item-icon" aria-hidden="true">❄️</span>
+                    <span class="nav-item-label">Snowflakes</span>
+                  </a>
+                </li>
               <% } %>
               <% if (canViewEvents) { %>
-                <li><a href="/admin/events">Événements</a></li>
+                <li>
+                  <a href="/admin/events">
+                    <span class="nav-item-icon" aria-hidden="true">🧾</span>
+                    <span class="nav-item-label">Événements</span>
+                  </a>
+                </li>
               <% } %>
               <% if (canManageUploads) { %>
-                <li><a href="/admin/uploads">Images</a></li>
+                <li>
+                  <a href="/admin/uploads">
+                    <span class="nav-item-icon" aria-hidden="true">🖼️</span>
+                    <span class="nav-item-label">Images</span>
+                  </a>
+                </li>
               <% } %>
               <% if (canManageSettings) { %>
-                <li><a href="/admin/settings">Paramètres</a></li>
+                <li>
+                  <a href="/admin/settings">
+                    <span class="nav-item-icon" aria-hidden="true">⚙️</span>
+                    <span class="nav-item-label">Paramètres</span>
+                  </a>
+                </li>
               <% } %>
             </ul>
           </section>

--- a/views/page.ejs
+++ b/views/page.ejs
@@ -5,7 +5,11 @@
     <div class="meta">
       <span>Créé: <%= page.created_at %></span>
       <% if (page.updated_at) { %><span>• Modifié: <%= page.updated_at %></span><% } %>
-      <span>• Auteur : <strong><%= page.author || 'Anonyme' %></strong></span>
+      <% const pageAuthorColor = page.authorRole && page.authorRole.color ? page.authorRole.color : null; %>
+      <% const pageAuthorClasses = ['user-handle', 'page-author']; %>
+      <% const pageAuthorStyle = pageAuthorColor && pageAuthorColor.hasColor ? pageAuthorColor.style : ''; %>
+      <% if (pageAuthorColor && pageAuthorColor.hasColor) { pageAuthorClasses.push('role-colored-text'); pageAuthorClasses.push(pageAuthorColor.className); } %>
+      <span>• Auteur : <strong class="<%= pageAuthorClasses.join(' ') %>" style="<%= pageAuthorStyle %>"><%= page.author || 'Anonyme' %></strong></span>
       <span>• Likes: <strong data-like-count-for="<%= page.slug_id %>"><%= page.likes %></strong></span>
       <span>• Commentaires: <strong><%= commentPagination.totalItems %></strong></span>
       <span>• Vues: <strong><%= page.views %></strong></span>
@@ -78,9 +82,12 @@
       <% comments.forEach(c => { %>
         <li class="comment">
           <div class="comment-meta">
-            <% const authorClasses = ['comment-author']; %>
+            <% const commentAuthorColor = c.authorRole && c.authorRole.color ? c.authorRole.color : null; %>
+            <% const authorClasses = ['comment-author', 'user-handle']; %>
             <% if (c.isAdminAuthor) { authorClasses.push('comment-author--admin'); } %>
-            <strong class="<%= authorClasses.join(' ') %>">
+            <% const commentAuthorStyle = commentAuthorColor && commentAuthorColor.hasColor ? commentAuthorColor.style : ''; %>
+            <% if (commentAuthorColor && commentAuthorColor.hasColor) { authorClasses.push('role-colored-text'); authorClasses.push(commentAuthorColor.className); } %>
+            <strong class="<%= authorClasses.join(' ') %>" style="<%= commentAuthorStyle %>">
               <%= c.author || 'Anonyme' %>
               <% if (c.isAdminAuthor) { %>
                 <span class="comment-author-badge" title="Administrateur">⭐</span>

--- a/views/revision.ejs
+++ b/views/revision.ejs
@@ -2,7 +2,16 @@
 <div class="card">
   <h1>Révision #<%= revision.revision %> de « <%= page.title %> »</h1>
   <p><strong>Titre enregistré :</strong> <%= revision.title %></p>
-  <p><strong>Auteur :</strong> <%= revision.author || 'Inconnu' %></p>
+  <% const revisionAuthorColor = revision.authorRole && revision.authorRole.color ? revision.authorRole.color : null; %>
+  <% const revisionAuthorClasses = ['user-handle', 'revision-author']; %>
+  <% const revisionAuthorStyle = revisionAuthorColor && revisionAuthorColor.hasColor ? revisionAuthorColor.style : ''; %>
+  <% if (revisionAuthorColor && revisionAuthorColor.hasColor) { revisionAuthorClasses.push('role-colored-text'); revisionAuthorClasses.push(revisionAuthorColor.className); } %>
+  <p>
+    <strong>Auteur :</strong>
+    <strong class="<%= revisionAuthorClasses.join(' ') %>" style="<%= revisionAuthorStyle %>">
+      <%= revision.author || 'Inconnu' %>
+    </strong>
+  </p>
   <p><strong>Horodatage :</strong> <%= revision.created_at %></p>
 </div>
 


### PR DESCRIPTION
## Summary
- add mobile close control and iconography to the navigation drawer, updating styles and toggle behaviour
- ensure role colours resolve consistently by introducing reusable helpers and applying them across pages, comments, history, and admin tools
- surface reviewer and author styling in submission workflows and statistics, including admin events listings

## Testing
- npm run db:init

------
https://chatgpt.com/codex/tasks/task_e_68de4b6cbd1083219cd05a015b113171