### PR TITLE
Adjust like button styling and remove redundant editor hint

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -388,6 +388,12 @@ pre {
   text-decoration: none;
 }
 
+.btn.like,
+.btn.unlike {
+  padding: 0.4rem 1rem;
+  font-size: 0.95rem;
+}
+
 .btn:hover,
 .btn:focus {
   transform: translateY(-1px);

--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -59,9 +59,6 @@
       aria-label="Éditeur de contenu"
     ></div>
   </div>
-  <p class="editor-hint">
-    Astuce : utilisez <code>[[Titre de page]]</code> pour créer des liens internes rapides.
-  </p>
   <label for="author-field">Auteur affiché</label>
   <input
     id="author-field"


### PR DESCRIPTION
## Summary
- shrink the like/unlike button styling to make the control more compact
- remove the redundant hint about internal links from the edit form

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68de5481a7c48321ae9d7a5c944a5b29